### PR TITLE
Adjust grid finding algorithm in item scan to be more accurate.

### DIFF
--- a/RatScanner/RatConfig.cs
+++ b/RatScanner/RatConfig.cs
@@ -89,7 +89,7 @@ namespace RatScanner
 			internal static float ConfWarnThreshold = 0.95f;
 			internal static bool ScanRotatedIcons = true;
 			internal static int ScanPadding => (int)(GetScreenScaleFactor() * 10);
-			internal static int ScanWidth => (int)(GetScreenScaleFactor() * 640);
+			internal static int ScanWidth => (int)(GetScreenScaleFactor() * 896);
 			internal static int ScanHeight => (int)(GetScreenScaleFactor() * 896);
 			internal static int ItemSlotSize = 63;
 			internal static Hotkey Hotkey = new Hotkey(new[] { Key.LeftShift }.ToList(), new[] { MouseButton.Left });

--- a/RatScanner/Scan/ItemIconScan.cs
+++ b/RatScanner/Scan/ItemIconScan.cs
@@ -30,7 +30,7 @@ namespace RatScanner.Scan
 		private const double GridSearchAvgScoreStop = 0.9;
 		private const double GridSearchEarlyMinScore = 0.25;
 		private const double GridDistanceScalingRate = 0.95;
-		private const int GridSearchMaxIterations = 20;
+		private const int GridSearchMaxIterations = 30;
 		private const int GridSearchMinIterations = 6;
 		private const int GridSearchEarlySearchIterations = 2;
 		private const double GridSearchPerfectScore = 0.95;
@@ -219,7 +219,7 @@ namespace RatScanner.Scan
 			return (position, size);
 		}
 
-		private (int, int, int, int, Vector2) FindGridEdgeDistances(Vector2 center)
+		private (int, int, int, int, Vector2) FindGridEdgeDistances(Vector2 center, int numIters = 0)
 		{
 			// Set up loop values
 			var orderIdx = 0;
@@ -229,7 +229,7 @@ namespace RatScanner.Scan
 			var downLimit = leftLimit;
 			var lastScores = new[] { 0.0, 0.0, 0.0, 0.0 };
 			var foundNewEdge = new[] { false, false, false, false };
-			var numIters = 0;
+			var myIters = 0;
 			var keepTrying = true;
 
 			while (keepTrying)
@@ -250,7 +250,7 @@ namespace RatScanner.Scan
 				var minScore = numIters < GridSearchMinIterations ? GridSearchEarlyMinScore : lastScores[orderIdx];
 				var (step, score) = FindGridEdgeDistance(direction.Item1, direction.Item2, center.X, center.Y,
 					GetSteps(direction.Item1, direction.Item2, center),
-					plus, minus, numIters >= GridSearchEarlySearchIterations, minScore);
+					plus, minus, myIters >= GridSearchEarlySearchIterations, minScore);
 
 				// Update scores and limits based on results
 				lastScores[orderIdx] = score;
@@ -290,7 +290,7 @@ namespace RatScanner.Scan
 
 					var newCenter = new Vector2(newX, center.Y);
 					Logger.LogDebug($"On Vertical Edge... Old Center: {center.X}, {center.Y}; New Center: {newCenter.X}, {newCenter.Y};");
-					return FindGridEdgeDistances(newCenter);
+					return FindGridEdgeDistances(newCenter, numIters);
 				}
 
 				if (upLimit == 0 && downLimit == 0)
@@ -301,7 +301,7 @@ namespace RatScanner.Scan
 
 					var newCenter = new Vector2(center.X, newY);
 					Logger.LogDebug($"On Horizontal Edge... Old Center: {center.X}, {center.Y}; New Center: {newCenter.X}, {newCenter.Y};");
-					return FindGridEdgeDistances(newCenter);
+					return FindGridEdgeDistances(newCenter, numIters);
 				}
 
 				// Log the current bounds if logging debug
@@ -318,6 +318,7 @@ namespace RatScanner.Scan
 
 				// Loop housekeeping
 				numIters++;
+				myIters++;
 				orderIdx = (orderIdx + 1) % _searchOrder.Count;
 
 				var avgScore = lastScores.Sum() / lastScores.Length;

--- a/RatScanner/Scan/ItemIconScan.cs
+++ b/RatScanner/Scan/ItemIconScan.cs
@@ -209,18 +209,18 @@ namespace RatScanner.Scan
 			Cv2.BitwiseAnd(_grid, mask, _grid);
 			Logger.LogDebugMat(_grid, "in_range_and_canny_edge_dilate");
 
-			var (lBorderDist, rBorderDist, tBorderDist, bBorderDist) =
+			var (lBorderDist, rBorderDist, tBorderDist, bBorderDist, center) =
 				FindGridEdgeDistances( new Vector2( _grid.Width / 2 - 1, _grid.Height / 2 - 1 ) );
 
-			var positionX = (RatConfig.IconScan.ScanWidth / 2) - lBorderDist;
-			var positionY = (RatConfig.IconScan.ScanHeight / 2) - bBorderDist;
+			var positionX = center.X - lBorderDist;
+			var positionY = center.Y - bBorderDist;
 			var position = new Vector2(positionX, positionY);
 
 			var size = new Vector2(rBorderDist + lBorderDist, tBorderDist + bBorderDist);
 			return (position, size);
 		}
 
-		private (int, int, int, int) FindGridEdgeDistances(Vector2 center)
+		private (int, int, int, int, Vector2) FindGridEdgeDistances(Vector2 center)
 		{
 			// Set up loop values
 			var orderIdx = 0;
@@ -341,7 +341,7 @@ namespace RatScanner.Scan
 				}
 			}
 
-			return ( lLimit, rLimit, uLimit, dLimit );
+			return ( lLimit, rLimit, uLimit, dLimit, center );
 		}
 
 		private (int, double) FindGridEdgeDistance(int up, int right, int x, int y, int steps, int plus, int minus, bool findBest = false, double minScore = 0.6)


### PR DESCRIPTION
Adjusted the way the program finds the edges of the item. Previously it was prone to errors because of false edges inside the item. Adjusted the way it searches for items to start with a small bounding box that grows as it finds new edges until it finds an acceptable set of edges. This on average takes about 2x the CPU time (only for grid search, CPU time difference is negligible in the grand scale of the icon scanner) with the top end limited because of the smaller search area. However, worst case can lead to 10+x the CPU time. Prior to this change in these worst case scenarios the scan failed more often than not. The overall CPU time is pretty negligible for the worst case and it is very rare, so I don't think it is an issue.

There are a few outstanding issues that I think should not prevent merging into the code base:
- Currently when viewing the stash, items towards the top center of the screen will have difficulty scanning. This is due to the wash out effect from the 'ceiling light' on the menu. Previously it also failed in this case.
- It can also sometimes fail if the game tooltip is up and positioned just right. It scales the edge score based on distance from center to try to correct for this. However, it isn't perfect. I think this is acceptable because the image classifier also frequently fails when the tooltip is up, and the previous edge detector also would sometimes fail when the tooltip was up. So ideally you scan prior to the tooltip popping up.