### PR TITLE
Add tag to filename in release workflow

### DIFF
--- a/.github/workflows/draftRelease.yml
+++ b/.github/workflows/draftRelease.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v2
+    - name: Set Workflow Tag Name
+      id: vars
+      run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
@@ -25,11 +28,11 @@ jobs:
     - name: Include Updater
       run: curl -L "https://github.com/RatScanner/RatUpdater/releases/latest/download/RatUpdater.exe" --output "publish/RatUpdater.exe"
     - name: Zip Content
-      run: 7z a -r RatScanner.zip ./publish/*
+      run: 7z a -r RatScanner-${{ steps.vars.outputs.tag }}.zip ./publish/*
     - name: Draft Release
       uses: softprops/action-gh-release@v1
       with:
-        files: RatScanner.zip
+        files: RatScanner-${{ steps.vars.outputs.tag }}.zip
         draft: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I just added some workflow stuff for TarkovTracker, similar to your draft release one. Something I wanted was to make sure the tag was in the artifact's filename. Seems like it would be useful for RatScanner as well, as I would expect users might download different versions of the zip files and have them in their downloads folder.