### PR TITLE
Trader Price & Color-coding for Tooltips

### DIFF
--- a/RatScanner/ItemExtensions.cs
+++ b/RatScanner/ItemExtensions.cs
@@ -188,11 +188,21 @@ namespace RatScanner
 			return marketItem ?? new MarketItem(item.Id);
 		}
 
+		public static int GetAvg24hMarketPricePerSlot(this Item item)
+		{
+			return item.GetAvg24hMarketPrice() / item.GetSlots();
+		}
+
 		public static int GetAvg24hMarketPrice(this Item item)
 		{
 			var total = item.GetMarketItem().Avg24hPrice;
 			if (item is CompoundItem itemC) total += itemC.Slots.Sum(slot => slot.ContainedItem?.GetAvg24hMarketPrice() ?? 0);
 			return total;
+		}
+
+		public static int GetMaxTraderPricePerSlot(this Item item)
+		{
+			return item.GetMaxTraderPrice() / item.GetSlots();
 		}
 
 		public static int GetMaxTraderPrice(this Item item)
@@ -213,6 +223,11 @@ namespace RatScanner
 			return total;
 		}
 
+		public static int GetSlots(this Item item)
+		{
+			return item.Width * item.Height;
+		}
+
 		public static (string traderId, int price) GetBestTrader(this Item item)
 		{
 			(string traderId, int price) result = ("", 0);
@@ -224,5 +239,7 @@ namespace RatScanner
 
 			return result;
 		}
+
+
 	}
 }

--- a/RatScanner/ItemExtensions.cs
+++ b/RatScanner/ItemExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using RatScanner.FetchModels;
 using System.Collections.Generic;
 using RatStash;
@@ -239,7 +238,5 @@ namespace RatScanner
 
 			return result;
 		}
-
-
 	}
 }

--- a/RatScanner/RatConfig.cs
+++ b/RatScanner/RatConfig.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -8,7 +6,6 @@ using System.Reflection;
 using System.Windows.Forms;
 using System.Windows.Input;
 using RatScanner.Controls;
-using RatScanner.Properties;
 
 namespace RatScanner
 {
@@ -65,8 +62,8 @@ namespace RatScanner
 			internal static string DigitGroupingSymbol = ".";
 			internal static int Duration = 1500;
 			internal static bool ShowFleaPrice = true;
-			internal static int FleaPricePerSlotThreshold = 0;
 			internal static bool ShowTraderPrice = false;
+			internal static int FleaPricePerSlotThreshold = 0;
 			internal static int TraderPricePerSlotThreshold = 0;
 		}
 
@@ -167,6 +164,10 @@ namespace RatScanner
 			config.Section = nameof(ToolTip);
 			ToolTip.Duration = config.ReadInt(nameof(ToolTip.Duration), 1500);
 			ToolTip.DigitGroupingSymbol = config.ReadString(nameof(ToolTip.DigitGroupingSymbol), NumberFormatInfo.CurrentInfo.NumberGroupSeparator);
+			ToolTip.ShowFleaPrice = config.ReadBool(nameof(ToolTip.ShowFleaPrice), true);
+			ToolTip.ShowTraderPrice = config.ReadBool(nameof(ToolTip.ShowTraderPrice), false);
+			ToolTip.FleaPricePerSlotThreshold = config.ReadInt(nameof(ToolTip.FleaPricePerSlotThreshold), 0);
+			ToolTip.TraderPricePerSlotThreshold = config.ReadInt(nameof(ToolTip.TraderPricePerSlotThreshold), 0);
 
 			config.Section = nameof(MinimalUi);
 			MinimalUi.ShowName = config.ReadBool(nameof(MinimalUi.ShowName), true);
@@ -213,6 +214,10 @@ namespace RatScanner
 			config.Section = nameof(ToolTip);
 			config.WriteInt(nameof(ToolTip.Duration), ToolTip.Duration);
 			config.WriteString(nameof(ToolTip.DigitGroupingSymbol), ToolTip.DigitGroupingSymbol);
+			config.WriteBool(nameof(ToolTip.ShowFleaPrice), ToolTip.ShowFleaPrice);
+			config.WriteBool(nameof(ToolTip.ShowTraderPrice), ToolTip.ShowTraderPrice);
+			config.WriteInt(nameof(ToolTip.FleaPricePerSlotThreshold), ToolTip.FleaPricePerSlotThreshold);
+			config.WriteInt(nameof(ToolTip.TraderPricePerSlotThreshold), ToolTip.TraderPricePerSlotThreshold);
 
 			config.Section = nameof(MinimalUi);
 			config.WriteBool(nameof(MinimalUi.ShowName), MinimalUi.ShowName);

--- a/RatScanner/RatConfig.cs
+++ b/RatScanner/RatConfig.cs
@@ -64,6 +64,10 @@ namespace RatScanner
 		{
 			internal static string DigitGroupingSymbol = ".";
 			internal static int Duration = 1500;
+			internal static bool ShowFleaPrice = true;
+			internal static int FleaPricePerSlotThreshold = 0;
+			internal static bool ShowTraderPrice = false;
+			internal static int TraderPricePerSlotThreshold = 0;
 		}
 
 		// Minimal UI

--- a/RatScanner/View/NameScanToolTip.xaml
+++ b/RatScanner/View/NameScanToolTip.xaml
@@ -16,12 +16,20 @@
 				WindowStyle="None"
 				mc:Ignorable="d">
 
-	<StackPanel>
-		<Label Padding="3,0"
-					 Background="{Binding WarningBrush}"
-					 Content="{Binding Avg24hPrice}"
+	<StackPanel Background="{Binding WarningBrush}">
+		<Label x:Name="FleaPriceDisplay"
+					 Padding="3,0"
+					 Content="{Binding FleaPrice}"
 					 FontFamily="Roboto Normal"
 					 FontWeight="Bold"
-					 Foreground="#000000" />
+					 Foreground="{Binding FleaPriceBrush}"
+					 HorizontalAlignment="Right"/>
+		<Label x:Name="TraderPriceDisplay"
+					 Padding="3,0"
+					 Content="{Binding MaxTraderPrice}"
+					 FontFamily="Roboto Normal"
+					 FontWeight="Bold"
+					 Foreground="{Binding TraderPriceBrush}"
+					 HorizontalAlignment="Right"/>
 	</StackPanel>
 </Window>

--- a/RatScanner/View/NameScanToolTip.xaml
+++ b/RatScanner/View/NameScanToolTip.xaml
@@ -19,17 +19,19 @@
 	<StackPanel Background="{Binding WarningBrush}">
 		<Label x:Name="FleaPriceDisplay"
 					 Padding="3,0"
-					 Content="{Binding FleaPrice}"
+					 Content="{Binding Avg24hMarketPrice}"
+					 d:Content="100.000€"
 					 FontFamily="Roboto Normal"
 					 FontWeight="Bold"
 					 Foreground="{Binding FleaPriceBrush}"
-					 HorizontalAlignment="Right"/>
+					 HorizontalAlignment="Right" />
 		<Label x:Name="TraderPriceDisplay"
 					 Padding="3,0"
 					 Content="{Binding MaxTraderPrice}"
+					 d:Content="50.000€"
 					 FontFamily="Roboto Normal"
 					 FontWeight="Bold"
 					 Foreground="{Binding TraderPriceBrush}"
-					 HorizontalAlignment="Right"/>
+					 HorizontalAlignment="Right" />
 	</StackPanel>
 </Window>

--- a/RatScanner/View/NameScanToolTip.xaml.cs
+++ b/RatScanner/View/NameScanToolTip.xaml.cs
@@ -66,6 +66,9 @@ namespace RatScanner.View
 			Left = vector2.X;
 			Top = vector2.Y;
 
+			FleaPriceDisplay.Visibility = RatConfig.ToolTip.ShowFleaPrice == true ? Visibility.Visible : Visibility.Collapsed;
+			TraderPriceDisplay.Visibility = RatConfig.ToolTip.ShowTraderPrice ? Visibility.Visible : Visibility.Collapsed;
+
 			Show();
 		}
 

--- a/RatScanner/View/NameScanToolTip.xaml.cs
+++ b/RatScanner/View/NameScanToolTip.xaml.cs
@@ -66,7 +66,7 @@ namespace RatScanner.View
 			Left = vector2.X;
 			Top = vector2.Y;
 
-			FleaPriceDisplay.Visibility = RatConfig.ToolTip.ShowFleaPrice == true ? Visibility.Visible : Visibility.Collapsed;
+			FleaPriceDisplay.Visibility = RatConfig.ToolTip.ShowFleaPrice ? Visibility.Visible : Visibility.Collapsed;
 			TraderPriceDisplay.Visibility = RatConfig.ToolTip.ShowTraderPrice ? Visibility.Visible : Visibility.Collapsed;
 
 			Show();

--- a/RatScanner/View/Settings.xaml
+++ b/RatScanner/View/Settings.xaml
@@ -162,9 +162,9 @@
 					<Grid>
 						<Grid.ToolTip>
 							<TextBlock>
-								Flea Price will be colored green or red if<LineBreak />
-								the Price per Slot is above or below the threshold.<LineBreak />
-								WARNING: Doesn't account for weapon attachements!
+								Flea Price will be colored green or red if the<LineBreak />
+								Price per Slot is above or below the threshold.<LineBreak />
+								WARNING:<LineBreak />Doesn't account for weapon attachements!
 							</TextBlock>
 						</Grid.ToolTip>
 						<Label Grid.Column="0"
@@ -199,9 +199,9 @@
 					<Grid>
 						<Grid.ToolTip>
 							<TextBlock>
-								Trader Price will be colored green or red if<LineBreak />
-								the Price per Slot is above or below the threshold.<LineBreak />
-								WARNING: Doesn't account for weapon attachements!
+								Trader Price will be colored green or red if the<LineBreak />
+								Price per Slot is above or below the threshold.<LineBreak />
+								WARNING:<LineBreak />Doesn't account for weapon attachements!
 							</TextBlock>
 						</Grid.ToolTip>
 						<Label Grid.Column="0"

--- a/RatScanner/View/Settings.xaml
+++ b/RatScanner/View/Settings.xaml
@@ -21,25 +21,6 @@
 					<Grid>
 						<Grid.ToolTip>
 							<TextBlock>
-								The duration in millisecond, how long<LineBreak />
-								the tool tip should be shown.
-							</TextBlock>
-						</Grid.ToolTip>
-						<Label Grid.Column="0"
-									 Content="ToolTip Duration" />
-						<TextBox Grid.Column="1"
-										 Width="100"
-										 Text="{Binding ToolTipDuration}" />
-
-						<Grid.ColumnDefinitions>
-							<ColumnDefinition Width="*" />
-							<ColumnDefinition Width="Auto" />
-						</Grid.ColumnDefinitions>
-					</Grid>
-
-					<Grid>
-						<Grid.ToolTip>
-							<TextBlock>
 								The resolution of your game. Adjust this to<LineBreak />
 								make sure both Name Scan and Icon Scan will work.
 							</TextBlock>
@@ -137,6 +118,103 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 					</Grid>
+				</StackPanel>
+			</TabItem>
+
+			<TabItem Header="Tooltip">
+				<StackPanel Margin="0, 5">
+					<Grid>
+						<Grid.ToolTip>
+							<TextBlock>
+								The duration in millisecond, how long<LineBreak />
+								the tool tip should be shown.
+							</TextBlock>
+						</Grid.ToolTip>
+						<Label Grid.Column="0"
+									 Content="Duration" />
+						<TextBox Grid.Column="1"
+										 Width="100"
+										 Text="{Binding ToolTipDuration}" />
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+					</Grid>
+					<Separator/>
+					<Grid>
+						<Grid.ToolTip>
+							<TextBlock>
+								Show the flea market price per slot of the item.
+							</TextBlock>
+						</Grid.ToolTip>
+						<Label Grid.Column="0"
+									 Content="Show Flea Price" />
+						<CheckBox Grid.Column="1"
+											Margin="5,0"
+											VerticalAlignment="Center"
+											IsChecked="{Binding ToolTipShowFleaPrice}" />
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+					</Grid>
+
+					<Grid>
+						<Grid.ToolTip>
+							<TextBlock>
+								Flea Price will be colored green or red if<LineBreak />
+								the Price per Slot is above or below the threshold.<LineBreak />
+								WARNING: Doesn't account for weapon attachements!
+							</TextBlock>
+						</Grid.ToolTip>
+						<Label Grid.Column="0"
+									 Content="Price per Slot Threshold" />
+						<TextBox Grid.Column="1"
+										 Width="90"
+										 Text="{Binding ToolTipFleaPricePerSlotThreshold}" />
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+					</Grid>
+					<Separator/>
+					<Grid>
+						<Grid.ToolTip>
+							<TextBlock>
+								Show the best trader price per slot of the item.
+							</TextBlock>
+						</Grid.ToolTip>
+						<Label Grid.Column="0"
+									 Content="Show Trader Price" />
+						<CheckBox Grid.Column="1"
+											Margin="5,0"
+											VerticalAlignment="Center"
+											IsChecked="{Binding ToolTipShowTraderPrice}" />
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+					</Grid>
+
+					<Grid>
+						<Grid.ToolTip>
+							<TextBlock>
+								Trader Price will be colored green or red if<LineBreak />
+								the Price per Slot is above or below the threshold.<LineBreak />
+								WARNING: Doesn't account for weapon attachements!
+							</TextBlock>
+						</Grid.ToolTip>
+						<Label Grid.Column="0"
+									 Content="Price per Slot Threshold" />
+						<TextBox Grid.Column="1"
+										 Width="90"
+										 Text="{Binding ToolTipTraderPricePerSlotThreshold}" />
+						<Grid.ColumnDefinitions>
+							<ColumnDefinition Width="*" />
+							<ColumnDefinition Width="Auto" />
+						</Grid.ColumnDefinitions>
+					</Grid>
+
 				</StackPanel>
 			</TabItem>
 
@@ -516,6 +594,7 @@
 					</TextBlock>
 				</StackPanel>
 			</TabItem>
+
 			<TabItem Header="Tracking">
 				<StackPanel Margin="0, 5">
 					<Grid>

--- a/RatScanner/View/Settings.xaml
+++ b/RatScanner/View/Settings.xaml
@@ -140,7 +140,7 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 					</Grid>
-					<Separator/>
+					<Separator />
 					<Grid>
 						<Grid.ToolTip>
 							<TextBlock>
@@ -164,7 +164,7 @@
 							<TextBlock>
 								Flea Price will be colored green or red if the<LineBreak />
 								Price per Slot is above or below the threshold.<LineBreak />
-								WARNING:<LineBreak />Doesn't account for weapon attachements!
+								WARNING:<LineBreak />Doesn't account for weapon attachments!
 							</TextBlock>
 						</Grid.ToolTip>
 						<Label Grid.Column="0"
@@ -177,7 +177,7 @@
 							<ColumnDefinition Width="Auto" />
 						</Grid.ColumnDefinitions>
 					</Grid>
-					<Separator/>
+					<Separator />
 					<Grid>
 						<Grid.ToolTip>
 							<TextBlock>
@@ -201,7 +201,7 @@
 							<TextBlock>
 								Trader Price will be colored green or red if the<LineBreak />
 								Price per Slot is above or below the threshold.<LineBreak />
-								WARNING:<LineBreak />Doesn't account for weapon attachements!
+								WARNING:<LineBreak />Doesn't account for weapon attachments!
 							</TextBlock>
 						</Grid.ToolTip>
 						<Label Grid.Column="0"

--- a/RatScanner/View/Settings.xaml.cs
+++ b/RatScanner/View/Settings.xaml.cs
@@ -55,8 +55,8 @@ namespace RatScanner.View
 
 			RatConfig.ToolTip.Duration = int.TryParse(settingsVM.ToolTipDuration, out var tooltipDuration) ? tooltipDuration : 0;
 			RatConfig.ToolTip.ShowFleaPrice = settingsVM.ToolTipShowFleaPrice;
-			RatConfig.ToolTip.FleaPricePerSlotThreshold = int.TryParse(settingsVM.ToolTipFleaPricePerSlotThreshold, out var tooltipFleaPriceThreshold) ? tooltipFleaPriceThreshold : 0;
 			RatConfig.ToolTip.ShowTraderPrice = settingsVM.ToolTipShowTraderPrice;
+			RatConfig.ToolTip.FleaPricePerSlotThreshold = int.TryParse(settingsVM.ToolTipFleaPricePerSlotThreshold, out var tooltipFleaPriceThreshold) ? tooltipFleaPriceThreshold : 0;
 			RatConfig.ToolTip.TraderPricePerSlotThreshold = int.TryParse(settingsVM.ToolTipTraderPricePerSlotThreshold, out var tooltipTraderPriceThreshold) ? tooltipTraderPriceThreshold : 0;
 
 			RatConfig.MinimalUi.ShowName = settingsVM.ShowName;

--- a/RatScanner/View/Settings.xaml.cs
+++ b/RatScanner/View/Settings.xaml.cs
@@ -53,7 +53,11 @@ namespace RatScanner.View
 			RatConfig.IconScan.UseCachedIcons = settingsVM.UseCachedIcons;
 			RatConfig.IconScan.Hotkey = settingsVM.IconScanHotkey;
 
-			RatConfig.ToolTip.Duration = int.TryParse(settingsVM.ToolTipDuration, out var i) ? i : 0;
+			RatConfig.ToolTip.Duration = int.TryParse(settingsVM.ToolTipDuration, out var tooltipDuration) ? tooltipDuration : 0;
+			RatConfig.ToolTip.ShowFleaPrice = settingsVM.ToolTipShowFleaPrice;
+			RatConfig.ToolTip.FleaPricePerSlotThreshold = int.TryParse(settingsVM.ToolTipFleaPricePerSlotThreshold, out var tooltipFleaPriceThreshold) ? tooltipFleaPriceThreshold : 0;
+			RatConfig.ToolTip.ShowTraderPrice = settingsVM.ToolTipShowTraderPrice;
+			RatConfig.ToolTip.TraderPricePerSlotThreshold = int.TryParse(settingsVM.ToolTipTraderPricePerSlotThreshold, out var tooltipTraderPriceThreshold) ? tooltipTraderPriceThreshold : 0;
 
 			RatConfig.MinimalUi.ShowName = settingsVM.ShowName;
 			RatConfig.MinimalUi.ShowAvgDayPrice = settingsVM.ShowAvgDayPrice;

--- a/RatScanner/ViewModel/SettingsVM.cs
+++ b/RatScanner/ViewModel/SettingsVM.cs
@@ -14,6 +14,10 @@ namespace RatScanner.ViewModel
 		public Hotkey IconScanHotkey { get; set; }
 
 		public string ToolTipDuration { get; set; }
+		public bool ToolTipShowFleaPrice { get; set; }
+		public string ToolTipFleaPricePerSlotThreshold { get; set; }
+		public bool ToolTipShowTraderPrice { get; set; }
+		public string ToolTipTraderPricePerSlotThreshold { get; set; }
 
 		public bool ShowName { get; set; }
 		public bool ShowAvgDayPrice { get; set; }
@@ -51,6 +55,10 @@ namespace RatScanner.ViewModel
 			IconScanHotkey = RatConfig.IconScan.Hotkey;
 
 			ToolTipDuration = RatConfig.ToolTip.Duration.ToString();
+			ToolTipShowFleaPrice = RatConfig.ToolTip.ShowFleaPrice;
+			ToolTipFleaPricePerSlotThreshold = RatConfig.ToolTip.FleaPricePerSlotThreshold.ToString();
+			ToolTipShowTraderPrice = RatConfig.ToolTip.ShowTraderPrice;
+			ToolTipTraderPricePerSlotThreshold = RatConfig.ToolTip.TraderPricePerSlotThreshold.ToString();
 
 			ShowName = RatConfig.MinimalUi.ShowName;
 			ShowAvgDayPrice = RatConfig.MinimalUi.ShowAvgDayPrice;

--- a/RatScanner/ViewModel/ToolTipVM.cs
+++ b/RatScanner/ViewModel/ToolTipVM.cs
@@ -1,10 +1,12 @@
 ﻿using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Media;
 using RatEye;
 using RatScanner.Scan;
+using RatScanner.View;
 using RatStash;
 using Brush = System.Windows.Media.Brush;
 using Color = System.Windows.Media.Color;
@@ -29,13 +31,10 @@ namespace RatScanner.ViewModel
 
 		// https://youtrack.jetbrains.com/issue/RSRP-468572
 		// ReSharper disable InconsistentNaming
-		public string Avg24hPrice => PriceToString(GetAvg24hPrice());
-
-		private int GetAvg24hPrice()
-		{
-			return MatchedItems[0].GetAvg24hMarketPrice();
-		}
+		public string FleaPrice => PriceToString(MatchedItems[0].GetAvg24hMarketPrice());
 		// ReSharper restore InconsistentNaming
+
+		public string MaxTraderPrice => PriceToString(MatchedItems[0].GetMaxTraderPrice());
 
 		public string IconPath => DataSource.IconPath ?? RatConfig.Paths.UnknownIcon;
 
@@ -55,6 +54,37 @@ namespace RatScanner.ViewModel
 
 				if (DataSource.Confidence < threshold) color = Color.FromRgb(227, 38, 25);
 				return new SolidColorBrush(color);
+			}
+		}
+
+		public Brush FleaPriceBrush
+		{
+			get
+			{
+				if (RatConfig.ToolTip.FleaPricePerSlotThreshold == 0)
+					return new SolidColorBrush(Color.FromRgb(0, 0, 0));
+
+				if (MatchedItems[0].GetAvg24hMarketPricePerSlot() >= RatConfig.ToolTip.FleaPricePerSlotThreshold)
+					return new SolidColorBrush(Color.FromRgb(0, 100, 0));
+
+				return new SolidColorBrush(Color.FromRgb(139, 0, 0));
+			}
+		}
+
+		public Brush TraderPriceBrush
+		{
+			get
+			{
+				if (RatConfig.ToolTip.TraderPricePerSlotThreshold == 0)
+					return new SolidColorBrush(Color.FromRgb(0, 0, 0));
+
+				var test1 = MatchedItems[0].GetMaxTraderPrice();
+				var test2 = MatchedItems[0].GetMaxTraderPricePerSlot();
+
+				if (MatchedItems[0].GetMaxTraderPricePerSlot() >= RatConfig.ToolTip.TraderPricePerSlotThreshold)
+					return new SolidColorBrush(Color.FromRgb(0, 100, 0));
+
+				return new SolidColorBrush(Color.FromRgb(139, 0, 0));
 			}
 		}
 

--- a/RatScanner/ViewModel/ToolTipVM.cs
+++ b/RatScanner/ViewModel/ToolTipVM.cs
@@ -1,12 +1,9 @@
 ﻿using System.ComponentModel;
-using System.Diagnostics;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Forms;
 using System.Windows.Media;
-using RatEye;
 using RatScanner.Scan;
-using RatScanner.View;
 using RatStash;
 using Brush = System.Windows.Media.Brush;
 using Color = System.Windows.Media.Color;
@@ -31,7 +28,7 @@ namespace RatScanner.ViewModel
 
 		// https://youtrack.jetbrains.com/issue/RSRP-468572
 		// ReSharper disable InconsistentNaming
-		public string FleaPrice => PriceToString(MatchedItems[0].GetAvg24hMarketPrice());
+		public string Avg24hMarketPrice => PriceToString(MatchedItems[0].GetAvg24hMarketPrice());
 		// ReSharper restore InconsistentNaming
 
 		public string MaxTraderPrice => PriceToString(MatchedItems[0].GetMaxTraderPrice());
@@ -77,9 +74,6 @@ namespace RatScanner.ViewModel
 			{
 				if (RatConfig.ToolTip.TraderPricePerSlotThreshold == 0)
 					return new SolidColorBrush(Color.FromRgb(0, 0, 0));
-
-				var test1 = MatchedItems[0].GetMaxTraderPrice();
-				var test2 = MatchedItems[0].GetMaxTraderPricePerSlot();
 
 				if (MatchedItems[0].GetMaxTraderPricePerSlot() >= RatConfig.ToolTip.TraderPricePerSlotThreshold)
 					return new SolidColorBrush(Color.FromRgb(0, 100, 0));


### PR DESCRIPTION
### Changelog

- Added Max Trader Price to ToolTip.
- Color-coded Flea & Max Trader Prices **per Slot** in Tooltip.
- Moved Tooltip settings into a separate category.
- Added toggle settings to Show/Hide Flea & Max Trader Prices in Tooltip.
  - By default, the Flea price is shown and the Trader Price is hidden.
- Added threshold settings for Price Color-coding.
  - By default, both thresholds are 0 which disables the Color-coding.
  - Hover Textbox warns that weapon size doesn't account for attachments.
![image](https://user-images.githubusercontent.com/4333206/133547551-5e08109c-03af-47b4-b16b-2cbdfa9bb3be.png)

### To-Do List
- [ ] Add Max Trader Price to IconScanToolTip
- [ ] Color-code Flea & Max Trader Prices in IconScanToolTip.

### Examples

![image](https://user-images.githubusercontent.com/4333206/133545963-1c0d7cfb-573f-43f1-9d3e-ec1dd58eed4d.png)
![image](https://user-images.githubusercontent.com/4333206/133546051-4620586e-7229-4b83-a0dc-0f603bcc477d.png)
![image](https://user-images.githubusercontent.com/4333206/133546167-34e2b7e5-30a6-4d4d-99d1-0dd89c5c0692.png)

