### PR TITLE
Add style WS_EX_TOOLWINDOW to blazor window

### DIFF
--- a/RatScanner/View/BlazorOverlay.xaml.cs
+++ b/RatScanner/View/BlazorOverlay.xaml.cs
@@ -53,11 +53,11 @@ public partial class BlazorOverlay : Window
 
 	private void SetWindowStyle()
 	{
-		const int GWL_EXSTYLE = -20;
-		const uint WS_EX_TOOLWINDOW = 0x00000080;
+		const int gwlExStyle = -20; // GWL_EXSTYLE
+		const uint wsExToolWindow = 0x00000080; // WS_EX_TOOLWINDOW
 
 		var handle = new WindowInteropHelper(this).Handle;
-		NativeMethods.SetWindowLongPtr(handle, GWL_EXSTYLE, NativeMethods.GetWindowLongPtr(handle, GWL_EXSTYLE) | (nint)WS_EX_TOOLWINDOW);
+		NativeMethods.SetWindowLongPtr(handle, gwlExStyle, NativeMethods.GetWindowLongPtr(handle, gwlExStyle) | (nint)wsExToolWindow);
 	}
 
 	private void WebView_Loaded(object sender, CoreWebView2NavigationCompletedEventArgs e)
@@ -71,7 +71,7 @@ public partial class BlazorOverlay : Window
 		blazorOverlayWebView.WebView.CoreWebView2.SetVirtualHostNameToFolderMapping("local.data", "Data", CoreWebView2HostResourceAccessKind.Allow);
 	}
 
-	private class NativeMethods
+	private static class NativeMethods
 	{
 		[DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
 		public static extern nint GetWindowLongPtr(nint hWnd, int nIndex);

--- a/RatScanner/View/BlazorOverlay.xaml.cs
+++ b/RatScanner/View/BlazorOverlay.xaml.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using System.Windows.Interop;
+using MudBlazor.Extensions;
 
 namespace RatScanner.View;
 
@@ -26,12 +27,10 @@ public partial class BlazorOverlay : Window
 	{
 		blazorOverlayWebView.WebView.DefaultBackgroundColor = System.Drawing.Color.Transparent;
 		SetSize();
+		SetWindowStyle();
 		blazorOverlayWebView.WebView.NavigationCompleted += WebView_Loaded;
 		blazorOverlayWebView.WebView.CoreWebView2InitializationCompleted += CoreWebView_Loaded;
 	}
-
-	[DllImport("user32.dll", SetLastError = true)]
-	static extern bool SetWindowPos(IntPtr hWnd, IntPtr hWndInsertAfter, int X, int Y, int cx, int cy, UInt32 uFlags);
 
 	private void SetSize()
 	{
@@ -49,7 +48,16 @@ public partial class BlazorOverlay : Window
 		}
 		
 		var handle = new WindowInteropHelper(this).Handle;
-		SetWindowPos(handle, (IntPtr)0, left, top, right - left, bottom - top, 0);
+		NativeMethods.SetWindowPos(handle, 0, left, top, right - left, bottom - top, 0);
+	}
+
+	private void SetWindowStyle()
+	{
+		const int GWL_EXSTYLE = -20;
+		const uint WS_EX_TOOLWINDOW = 0x00000080;
+
+		var handle = new WindowInteropHelper(this).Handle;
+		NativeMethods.SetWindowLongPtr(handle, GWL_EXSTYLE, NativeMethods.GetWindowLongPtr(handle, GWL_EXSTYLE) | (nint)WS_EX_TOOLWINDOW);
 	}
 
 	private void WebView_Loaded(object sender, CoreWebView2NavigationCompletedEventArgs e)
@@ -61,5 +69,17 @@ public partial class BlazorOverlay : Window
 	private void CoreWebView_Loaded(object sender, CoreWebView2InitializationCompletedEventArgs e)
 	{
 		blazorOverlayWebView.WebView.CoreWebView2.SetVirtualHostNameToFolderMapping("local.data", "Data", CoreWebView2HostResourceAccessKind.Allow);
+	}
+
+	private class NativeMethods
+	{
+		[DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
+		public static extern nint GetWindowLongPtr(nint hWnd, int nIndex);
+
+		[DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
+		public static extern nint SetWindowLongPtr(nint hWnd, int nIndex, nint dwNewLong);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		public static extern bool SetWindowPos(nint hWnd, nint hWndInsertAfter, int X, int Y, int cx, int cy, uint uFlags);
 	}
 }


### PR DESCRIPTION
This commit attempts to fix discord streaming issue by adding a new [extended window style](https://docs.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles).
This is done by getting the current window style through
user32.dll::GetWindow and BOR'ing in WS_EX_TOOLWINDOW.

This will also fix the transparent overlay showing in the ALT+TAB
screen.

Note that the NativeMethods GetWindowLongPtr and SetWindowLongPtr are
x64 specific. If x86 capability is required, then you must setup logic
to call the GetWindowLong/SetWindowLong exports.

Closes: #155