### PR TITLE
Fix double-counting of kappa items

### DIFF
--- a/RatScanner/ItemExtensions.cs
+++ b/RatScanner/ItemExtensions.cs
@@ -50,7 +50,6 @@ public static class ItemExtensions {
 					if ((!oGiveItem.Items?.Any(i => i?.Id == item.Id)) ?? true) continue;	// Skip if item is not the one we are looking for
 					if (!showNonFir && !oGiveItem.FoundInRaid) continue;					// Skip if item is not FIR
 					needed = oGiveItem.Count;
-					if (task.KappaRequired == true) kappaCount += oGiveItem.Count;
 					// Subtract amount of already collected items
 					List<Progress> objectiveProgress = progress.TaskObjectives.Where(p => p.Id == objective.Id).ToList();
 					foreach (Progress p in objectiveProgress) needed -= p.Complete ? oGiveItem.Count : p.Count;


### PR DESCRIPTION
There was a double-counting going on with the kappa items counter, sorry for that

The fix is easy, and bellow is a test with 3.9 vs the fix on top of develop branch

Before

<img width="278" height="467" alt="image" src="https://github.com/user-attachments/assets/95f4d236-803e-4fe4-a4b3-3d1acec460cd" />

After

<img width="269" height="441" alt="image" src="https://github.com/user-attachments/assets/3d739381-ba3d-4002-87c9-1fdd24f364da" />
