### PR TITLE
Fix "Show Non-FIR Needs" for Hideout Upgrade Needs

### DIFF
--- a/RatScanner/ItemExtensions.cs
+++ b/RatScanner/ItemExtensions.cs
@@ -89,6 +89,8 @@ public static class ItemExtensions {
 	public static int GetHideoutRemaining(this Item item, UserProgress? progress = null) {
 		progress ??= GetUserProgress();
 
+		bool showNonFir = RatConfig.Tracking.ShowNonFIRNeeds;
+
 		int count = 0;
 		HideoutStation[] stations = TarkovDevAPI.GetHideoutStations();
 
@@ -103,6 +105,9 @@ public static class ItemExtensions {
 				if (level?.ItemRequirements == null) continue;
 				foreach (RequirementItem? requiredItem in level.ItemRequirements) {
 					if (requiredItem?.Item?.Id != item.Id) continue;
+
+					bool FoundInRaid = bool.Parse((from x in requiredItem.Attributes where x.Type == "foundInRaid" select x.Value).FirstOrDefault("true"));
+					if (!showNonFir && !FoundInRaid) continue;                    // Skip if item is not FIR
 
 					count += requiredItem.Count;
 					List<Progress> objectiveProgress = progress.HideoutParts.Where(p => p.Id == requiredItem.Id).ToList();

--- a/RatScanner/TarkovDevAPI.cs
+++ b/RatScanner/TarkovDevAPI.cs
@@ -354,6 +354,7 @@ public static class TarkovDevAPI {
 		return new QueryQueryBuilder().WithHideoutStations(new HideoutStationQueryBuilder().WithAllScalarFields()
 			.WithLevels(new HideoutStationLevelQueryBuilder().WithAllScalarFields()
 				.WithItemRequirements(new RequirementItemQueryBuilder().WithAllScalarFields()
+					.WithAttributes(new ItemAttributeQueryBuilder().WithAllScalarFields())
 					.WithItem(new ItemQueryBuilder().WithAllScalarFields()))
 				.WithStationLevelRequirements(new RequirementHideoutStationLevelQueryBuilder().WithAllScalarFields()
 					.WithStation(new HideoutStationQueryBuilder().WithAllScalarFields()))


### PR DESCRIPTION
Fixes https://github.com/RatScanner/RatScanner/issues/764

The "Show Non-FIR Needs" checkbox now works as expected for both Quest and Hideout items.

**Test:**

**Graphics Card**
Show Non-FIR Needs **CHECKED**
43 Quest . 0 Hideout
Show Non-FIR Needs **UNCHECKED**
13 Quest . 0 Hideout

**CPU Fan**
Show Non-FIR Needs **CHECKED**
25 Quest . 60 Hideout
Show Non-FIR Needs **UNCHECKED**
25 Quest . 25 Hideout