### PR TITLE
Fix API rate limiting and improve startup performance

### DIFF
--- a/RatScanner/MapDataLoader.cs
+++ b/RatScanner/MapDataLoader.cs
@@ -48,15 +48,20 @@ public static class MapDataLoader
 	private static Dictionary<string, Map> BuildMapIdCache(List<InteractiveMapData> mapsData)
 	{
 		Dictionary<string, Map> cache = new();
-		
+		var tarkovDevMaps = TarkovDevAPI.GetMaps();
+
 		foreach (InteractiveMapData mapData in mapsData) {
 			if (mapData.Maps == null) continue;
-			
-			foreach (InteractiveMapData.Map map in mapData.Maps) {
+
+			foreach (Map map in mapData.Maps) {
 				if (string.IsNullOrEmpty(map.Key)) continue;
 				if (map.Projection != "interactive") continue;
 
-				var tMap = TarkovDevAPI.GetMaps().FirstOrDefault(m => m.NormalizedName == mapData.NormalizedName);
+				var tMap = tarkovDevMaps.FirstOrDefault(m => m.NormalizedName == mapData.NormalizedName);
+				if (tMap == null) {
+					Logger.LogWarning($"No TarkovDev map match for normalized name: {mapData.NormalizedName}");
+					continue;
+				}
 				cache[tMap.Id] = map;
 			}
 		}
@@ -74,7 +79,7 @@ public static class MapDataLoader
 		// Trigger loading if not already loaded
 		GetMapsData();
 		
-		return _mapsByIdCache ?? new();
+		return _mapsByIdCache ?? [];
 	}
 	
 	/// <summary>

--- a/RatScanner/MapDataLoader.cs
+++ b/RatScanner/MapDataLoader.cs
@@ -48,19 +48,24 @@ public static class MapDataLoader
 	private static Dictionary<string, Map> BuildMapIdCache(List<InteractiveMapData> mapsData)
 	{
 		Dictionary<string, Map> cache = new();
-		
+		var tarkovDevMaps = TarkovDevAPI.GetMaps();
+
 		foreach (InteractiveMapData mapData in mapsData) {
 			if (mapData.Maps == null) continue;
-			
+
 			foreach (InteractiveMapData.Map map in mapData.Maps) {
 				if (string.IsNullOrEmpty(map.Key)) continue;
 				if (map.Projection != "interactive") continue;
 
-				var tMap = TarkovDevAPI.GetMaps().FirstOrDefault(m => m.NormalizedName == mapData.NormalizedName);
+				var tMap = tarkovDevMaps.FirstOrDefault(m => m.NormalizedName == mapData.NormalizedName);
+				if (tMap == null) {
+					Logger.LogWarning($"No TarkovDev map match for normalized name: {mapData.NormalizedName}");
+					continue;
+				}
 				cache[tMap.Id] = map;
 			}
 		}
-		
+
 		return cache;
 	}
 	

--- a/RatScanner/RatConfig.cs
+++ b/RatScanner/RatConfig.cs
@@ -311,19 +311,24 @@ internal static class RatConfig {
 	}
 
 	internal static bool ReadFromCache(string key, out string value) {
-		byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(key));
-		string hash = string.Concat(Array.ConvertAll(hashBytes, b => b.ToString("X2")));
+		return ReadFromCache(key, out value, out _);
+	}
 
-		string path = Path.Combine(Paths.CacheDir, hash + ".data");
+	internal static bool ReadFromCache(string key, out string value, out DateTimeOffset lastWriteUtc) {
+		string path = GetCachePath(key);
 		value = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+		lastWriteUtc = File.Exists(path) ? File.GetLastWriteTimeUtc(path) : DateTimeOffset.MinValue;
 		return value != string.Empty;
 	}
 
-	internal static void WriteToCache(string key, string value) {
+	internal static string GetCachePath(string key) {
 		byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(key));
 		string hash = string.Concat(Array.ConvertAll(hashBytes, b => b.ToString("X2")));
+		return Path.Combine(Paths.CacheDir, hash + ".data");
+	}
 
-		string path = Path.Combine(Paths.CacheDir, hash + ".data");
+	internal static void WriteToCache(string key, string value) {
+		string path = GetCachePath(key);
 		Directory.CreateDirectory(Paths.CacheDir);
 		File.WriteAllText(path, value);
 	}

--- a/RatScanner/RatConfig.cs
+++ b/RatScanner/RatConfig.cs
@@ -324,19 +324,24 @@ internal static class RatConfig {
 	}
 
 	internal static bool ReadFromCache(string key, out string value) {
-		byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(key));
-		string hash = string.Concat(Array.ConvertAll(hashBytes, b => b.ToString("X2")));
+		return ReadFromCache(key, out value, out _);
+	}
 
-		string path = Path.Combine(Paths.CacheDir, hash + ".data");
+	internal static bool ReadFromCache(string key, out string value, out DateTimeOffset lastWriteUtc) {
+		string path = GetCachePath(key);
 		value = File.Exists(path) ? File.ReadAllText(path) : string.Empty;
+		lastWriteUtc = File.Exists(path) ? File.GetLastWriteTimeUtc(path) : DateTimeOffset.MinValue;
 		return value != string.Empty;
 	}
 
-	internal static void WriteToCache(string key, string value) {
+	internal static string GetCachePath(string key) {
 		byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(key));
 		string hash = string.Concat(Array.ConvertAll(hashBytes, b => b.ToString("X2")));
+		return Path.Combine(Paths.CacheDir, hash + ".data");
+	}
 
-		string path = Path.Combine(Paths.CacheDir, hash + ".data");
+	internal static void WriteToCache(string key, string value) {
+		string path = GetCachePath(key);
 		Directory.CreateDirectory(Paths.CacheDir);
 		File.WriteAllText(path, value);
 	}

--- a/RatScanner/RatScanner.csproj
+++ b/RatScanner/RatScanner.csproj
@@ -7,7 +7,7 @@
 		<UseWindowsForms>True</UseWindowsForms>
 		<ApplicationIcon>Resources\RatLogoSmall.ico</ApplicationIcon>
 		<StartupObject>RatScanner.App</StartupObject>
-		<Version>3.9.2</Version>
+		<Version>3.9.3</Version>
 		<ImplicitUsings>disable</ImplicitUsings>
 		<AddRazorSupportForMvc>true</AddRazorSupportForMvc>
 		<RootNamespace>RatScanner</RootNamespace>

--- a/RatScanner/RatScannerMain.cs
+++ b/RatScanner/RatScannerMain.cs
@@ -10,12 +10,14 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
 using MessageBox = System.Windows.MessageBox;
 using PixelFormat = System.Drawing.Imaging.PixelFormat;
 using Size = System.Drawing.Size;
 using Timer = System.Threading.Timer;
+using TarkovItem = RatScanner.TarkovDev.GraphQL.Item;
 
 namespace RatScanner;
 
@@ -66,17 +68,19 @@ public class RatScannerMain : INotifyPropertyChanged {
 		
 		// Try to load from offline cache first for faster startup
 		if (TarkovDevAPI.TryInitializeCacheFromOffline()) {
-			// Cache loaded from offline storage, queue background refresh
-			Logger.LogInfo("Using offline cache for fast startup, refreshing in background...");
-			_ = TarkovDevAPI.InitializeCache();
+			if (TarkovDevAPI.AnyCacheExpired()) {
+				Logger.LogInfo("Offline cache loaded but stale, refreshing in background...");
+				_ = TarkovDevAPI.InitializeCache();
+			} else {
+				Logger.LogInfo("Offline cache loaded and fresh, skipping background refresh.");
+			}
 		} else {
 			// No offline cache available, wait for network requests
 			Logger.LogWarning("No complete offline cache available, fetching from network...");
-			TarkovDevAPI.InitializeCache().Wait();
+			_ = TarkovDevAPI.InitializeCache();
 		}
 
-		var items = TarkovDevAPI.GetItems();
-		ItemScans.Enqueue(new DefaultItemScan(items[new Random().Next(items.Length)]));
+		SeedInitialItem();
 
 		Logger.LogInfo("Initializing tarkov tracker database");
 		TarkovTrackerDB = new TarkovTrackerDB();
@@ -119,7 +123,7 @@ public class RatScannerMain : INotifyPropertyChanged {
 
 	private void CheckForUpdates() {
 		string mostRecentVersion = ApiManager.GetResource(ApiManager.ResourceType.ClientVersion);
-		if (RatConfig.Version == mostRecentVersion) return;
+		if (!IsNewerVersionAvailable(RatConfig.Version, mostRecentVersion)) return;
 		Logger.LogInfo("A new version is available: " + mostRecentVersion);
 
 		string forceVersions = ApiManager.GetResource(ApiManager.ResourceType.ClientForceUpdateVersions);
@@ -133,6 +137,28 @@ public class RatScannerMain : INotifyPropertyChanged {
 		message += "Do you want to install it now?";
 		MessageBoxResult result = MessageBox.Show(message, "Rat Scanner Updater", MessageBoxButton.YesNo);
 		if (result == MessageBoxResult.Yes) UpdateRatScanner();
+	}
+
+	private static bool IsNewerVersionAvailable(string currentVersion, string availableVersion) {
+		if (TryParseVersion(currentVersion, out Version current) && TryParseVersion(availableVersion, out Version available)) {
+			return available > current;
+		}
+
+		// If parsing fails, don't prompt for update to avoid false positives
+		return false;
+	}
+
+	private static bool TryParseVersion(string versionText, out Version version) {
+		version = new Version(0, 0);
+		if (string.IsNullOrWhiteSpace(versionText)) return false;
+
+		string cleaned = versionText.Trim();
+		if (cleaned.StartsWith("v", StringComparison.OrdinalIgnoreCase)) cleaned = cleaned.Substring(1);
+
+		int cut = cleaned.IndexOfAny(new[] { '-', '+' });
+		if (cut >= 0) cleaned = cleaned.Substring(0, cut);
+
+		return Version.TryParse(cleaned, out version);
 	}
 
 	private void UpdateRatScanner() {
@@ -185,7 +211,12 @@ public class RatScannerMain : INotifyPropertyChanged {
 
 	private Database RatStashDatabaseFromTarkovDev() {
 		List<Item> rsItems = new();
-		foreach (TarkovDev.GraphQL.Item i in TarkovDevAPI.GetItems()) {
+		if (!TarkovDevAPI.TryGetCachedItems(out TarkovDev.GraphQL.Item[] items) || items.Length == 0) {
+			Logger.LogWarning("Items cache not ready; initializing RatEye with empty item database.");
+			return RatStash.Database.FromItems(rsItems);
+		}
+
+		foreach (TarkovDev.GraphQL.Item i in items) {
 			rsItems.Add(new RatStash.Item() {
 				Id = i.Id,
 				Name = i.Name,
@@ -194,6 +225,47 @@ public class RatScannerMain : INotifyPropertyChanged {
 			});
 		}
 		return RatStash.Database.FromItems(rsItems);
+	}
+
+	private void SeedInitialItem() {
+		if (TarkovDevAPI.TryGetCachedItems(out TarkovItem[] items) && items.Length > 0) {
+			ItemScans.Enqueue(new DefaultItemScan(items[new Random().Next(items.Length)]));
+			return;
+		}
+
+		ItemScans.Enqueue(new DefaultItemScan(CreatePlaceholderItem()));
+		_ = Task.Run(() => WaitForItemsAndSeedAsync(TimeSpan.FromSeconds(30)));
+	}
+
+	private async Task WaitForItemsAndSeedAsync(TimeSpan timeout) {
+		Stopwatch sw = Stopwatch.StartNew();
+		while (sw.Elapsed < timeout) {
+			if (TarkovDevAPI.TryGetCachedItems(out TarkovItem[] items) && items.Length > 0) {
+				ItemScans.Enqueue(new DefaultItemScan(items[new Random().Next(items.Length)]));
+				Logger.LogInfo("Items cache ready; reinitializing RatEye...");
+				SetupRatEye();
+				RefreshOverlay();
+				return;
+			}
+			await Task.Delay(500).ConfigureAwait(false);
+		}
+		Logger.LogWarning("Timed out waiting for items cache to populate.");
+	}
+
+	private static TarkovItem CreatePlaceholderItem() {
+		return new TarkovItem {
+			Id = "loading",
+			Name = "Loading...",
+			ShortName = "Loading...",
+			Avg24HPrice = 0,
+			Width = 1,
+			Height = 1,
+			Updated = DateTime.UtcNow.ToString("O"),
+			IconLink = "https://assets.tarkov.dev/unknown-item-grid-image.jpg",
+			BaseImageLink = "https://assets.tarkov.dev/unknown-item-grid-image.jpg",
+			Link = "https://tarkov.dev/",
+			WikiLink = "",
+		};
 	}
 
 	/// <summary>
@@ -321,13 +393,13 @@ public class RatScannerMain : INotifyPropertyChanged {
 	private void RefreshTarkovTrackerDB(object? o = null) {
 		Logger.LogInfo("Refreshing TarkovTracker DB...");
 		TarkovTrackerDB.Init();
-		_tarkovTrackerDBRefreshTimer.Change(RatConfig.Tracking.TarkovTracker.RefreshTime, Timeout.Infinite);
+		_tarkovTrackerDBRefreshTimer?.Change(RatConfig.Tracking.TarkovTracker.RefreshTime, Timeout.Infinite);
 	}
 	private void RefreshOverlay(object? o = null) {
 		OnPropertyChanged();
 	}
 
-	protected virtual void OnPropertyChanged(string propertyName = null) {
+	protected virtual void OnPropertyChanged(string? propertyName = null) {
 		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 	}
 }

--- a/RatScanner/RatScannerMain.cs
+++ b/RatScanner/RatScannerMain.cs
@@ -10,12 +10,14 @@ using System.Drawing;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Forms;
 using MessageBox = System.Windows.MessageBox;
 using PixelFormat = System.Drawing.Imaging.PixelFormat;
 using Size = System.Drawing.Size;
 using Timer = System.Threading.Timer;
+using TarkovItem = RatScanner.TarkovDev.GraphQL.Item;
 
 namespace RatScanner;
 
@@ -66,20 +68,22 @@ public class RatScannerMain : INotifyPropertyChanged {
 		Logger.LogInfo($"Screen Info: {RatConfig.ScreenWidth}x{RatConfig.ScreenHeight} at {RatConfig.ScreenScale * 100}%");
 
 		Logger.LogInfo("Initializing TarkovDev API...");
-		
+
 		// Try to load from offline cache first for faster startup
 		if (TarkovDevAPI.TryInitializeCacheFromOffline()) {
-			// Cache loaded from offline storage, queue background refresh
-			Logger.LogInfo("Using offline cache for fast startup, refreshing in background...");
-			_ = TarkovDevAPI.InitializeCache();
+			if (TarkovDevAPI.AnyCacheExpired()) {
+				Logger.LogInfo("Offline cache loaded but stale, refreshing in background...");
+				_ = TarkovDevAPI.InitializeCache();
+			} else {
+				Logger.LogInfo("Offline cache loaded and fresh, skipping background refresh.");
+			}
 		} else {
 			// No offline cache available, wait for network requests
 			Logger.LogWarning("No complete offline cache available, fetching from network...");
-			TarkovDevAPI.InitializeCache().Wait();
+			_ = TarkovDevAPI.InitializeCache();
 		}
 
-		var items = TarkovDevAPI.GetItems();
-		ItemScans.Enqueue(new DefaultItemScan(items[new Random().Next(items.Length)]));
+		SeedInitialItem();
 
 		Logger.LogInfo("Initializing tarkov tracker database");
 		TarkovTrackerDB = new TarkovTrackerDB();
@@ -119,7 +123,7 @@ public class RatScannerMain : INotifyPropertyChanged {
 
 	private void CheckForUpdates() {
 		string mostRecentVersion = ApiManager.GetResource(ApiManager.ResourceType.ClientVersion);
-		if (RatConfig.Version == mostRecentVersion) return;
+		if (!IsNewerVersionAvailable(RatConfig.Version, mostRecentVersion)) return;
 		Logger.LogInfo("A new version is available: " + mostRecentVersion);
 
 		string forceVersions = ApiManager.GetResource(ApiManager.ResourceType.ClientForceUpdateVersions);
@@ -133,6 +137,28 @@ public class RatScannerMain : INotifyPropertyChanged {
 		message += "Do you want to install it now?";
 		MessageBoxResult result = MessageBox.Show(message, "Rat Scanner Updater", MessageBoxButton.YesNo);
 		if (result == MessageBoxResult.Yes) UpdateRatScanner();
+	}
+
+	private static bool IsNewerVersionAvailable(string currentVersion, string availableVersion) {
+		if (TryParseVersion(currentVersion, out Version current) && TryParseVersion(availableVersion, out Version available)) {
+			return available > current;
+		}
+
+		// If parsing fails, don't prompt for update to avoid false positives
+		return false;
+	}
+
+	private static bool TryParseVersion(string versionText, out Version version) {
+		version = new Version(0, 0);
+		if (string.IsNullOrWhiteSpace(versionText)) return false;
+
+		string cleaned = versionText.Trim();
+		if (cleaned.StartsWith("v", StringComparison.OrdinalIgnoreCase)) cleaned = cleaned.Substring(1);
+
+		int cut = cleaned.IndexOfAny(new[] { '-', '+' });
+		if (cut >= 0) cleaned = cleaned.Substring(0, cut);
+
+		return Version.TryParse(cleaned, out version);
 	}
 
 	private void UpdateRatScanner() {
@@ -185,7 +211,12 @@ public class RatScannerMain : INotifyPropertyChanged {
 
 	private Database RatStashDatabaseFromTarkovDev() {
 		List<Item> rsItems = new();
-		foreach (TarkovDev.GraphQL.Item i in TarkovDevAPI.GetItems()) {
+		if (!TarkovDevAPI.TryGetCachedItems(out TarkovDev.GraphQL.Item[] items) || items.Length == 0) {
+			Logger.LogWarning("Items cache not ready; initializing RatEye with empty item database.");
+			return RatStash.Database.FromItems(rsItems);
+		}
+
+		foreach (TarkovDev.GraphQL.Item i in items) {
 			rsItems.Add(new RatStash.Item() {
 				Id = i.Id,
 				Name = i.Name,
@@ -194,6 +225,47 @@ public class RatScannerMain : INotifyPropertyChanged {
 			});
 		}
 		return RatStash.Database.FromItems(rsItems);
+	}
+
+	private void SeedInitialItem() {
+		if (TarkovDevAPI.TryGetCachedItems(out TarkovItem[] items) && items.Length > 0) {
+			ItemScans.Enqueue(new DefaultItemScan(items[new Random().Next(items.Length)]));
+			return;
+		}
+
+		ItemScans.Enqueue(new DefaultItemScan(CreatePlaceholderItem()));
+		_ = Task.Run(() => WaitForItemsAndSeedAsync(TimeSpan.FromSeconds(30)));
+	}
+
+	private async Task WaitForItemsAndSeedAsync(TimeSpan timeout) {
+		Stopwatch sw = Stopwatch.StartNew();
+		while (sw.Elapsed < timeout) {
+			if (TarkovDevAPI.TryGetCachedItems(out TarkovItem[] items) && items.Length > 0) {
+				ItemScans.Enqueue(new DefaultItemScan(items[new Random().Next(items.Length)]));
+				Logger.LogInfo("Items cache ready; reinitializing RatEye...");
+				SetupRatEye();
+				RefreshOverlay();
+				return;
+			}
+			await Task.Delay(500).ConfigureAwait(false);
+		}
+		Logger.LogWarning("Timed out waiting for items cache to populate.");
+	}
+
+	private static TarkovItem CreatePlaceholderItem() {
+		return new TarkovItem {
+			Id = "loading",
+			Name = "Loading...",
+			ShortName = "Loading...",
+			Avg24HPrice = 0,
+			Width = 1,
+			Height = 1,
+			Updated = DateTime.UtcNow.ToString("O"),
+			IconLink = "https://assets.tarkov.dev/unknown-item-grid-image.jpg",
+			BaseImageLink = "https://assets.tarkov.dev/unknown-item-grid-image.jpg",
+			Link = "https://tarkov.dev/",
+			WikiLink = "",
+		};
 	}
 
 	/// <summary>
@@ -321,13 +393,13 @@ public class RatScannerMain : INotifyPropertyChanged {
 	private void RefreshTarkovTrackerDB(object? o = null) {
 		Logger.LogInfo("Refreshing TarkovTracker DB...");
 		TarkovTrackerDB.Init();
-		_tarkovTrackerDBRefreshTimer.Change(RatConfig.Tracking.TarkovTracker.RefreshTime, Timeout.Infinite);
+		_tarkovTrackerDBRefreshTimer?.Change(RatConfig.Tracking.TarkovTracker.RefreshTime, Timeout.Infinite);
 	}
 	private void RefreshOverlay(object? o = null) {
 		OnPropertyChanged();
 	}
 
-	protected virtual void OnPropertyChanged(string propertyName = null) {
+	protected virtual void OnPropertyChanged(string? propertyName = null) {
 		PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 	}
 }

--- a/RatScanner/TarkovDevAPI.cs
+++ b/RatScanner/TarkovDevAPI.cs
@@ -341,46 +341,33 @@ public static class TarkovDevAPI {
 
 	private static string ItemsQuery() => ItemsQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string ItemsQuery(LanguageCode language, GameMode gameMode) {
-		string lang = ToGraphQlEnum(language);
-		string mode = ToGraphQlEnum(gameMode);
-		return $@"query {{
-  data: items(lang: {lang}, gameMode: {mode}) {{
-    id
-    name
-    shortName
-    iconLink
-    baseImageLink
-    link
-    wikiLink
-    avg24hPrice
-    width
-    height
-    updated
-    types
-    properties {{
-      __typename
-      ... on ItemPropertiesAmmo {{
-        caliber
-        damage
-        penetrationPower
-        fragmentationChance
-      }}
-    }}
-    sellFor {{
-      priceRUB
-      vendor {{
-        __typename
-        ... on TraderOffer {{
-          name
-          trader {{
-            name
-            imageLink
-          }}
-        }}
-      }}
-    }}
-  }}
-}}";
+		return new QueryQueryBuilder().WithItems(new ItemQueryBuilder().WithAllScalarFields()
+		.WithProperties(new ItemPropertiesQueryBuilder().WithAllScalarFields()
+			.WithItemPropertiesAmmoFragment(new ItemPropertiesAmmoQueryBuilder().WithAllScalarFields())
+			.WithItemPropertiesFoodDrinkFragment(new ItemPropertiesFoodDrinkQueryBuilder().WithAllScalarFields()
+				.WithStimEffects(new StimEffectQueryBuilder().WithAllScalarFields()))
+			.WithItemPropertiesStimFragment(new ItemPropertiesStimQueryBuilder().WithAllScalarFields()
+				.WithStimEffects(new StimEffectQueryBuilder().WithAllScalarFields()))
+			.WithItemPropertiesMedicalItemFragment(new ItemPropertiesMedicalItemQueryBuilder().WithAllScalarFields())
+			.WithItemPropertiesMedKitFragment(new ItemPropertiesMedKitQueryBuilder().WithAllScalarFields()))
+		.WithSellFor(new ItemPriceQueryBuilder().WithAllScalarFields()
+			.WithVendor(new VendorQueryBuilder().WithAllScalarFields()
+				.WithTraderOfferFragment(new TraderOfferQueryBuilder().WithAllScalarFields()
+					.WithTrader(new TraderQueryBuilder().WithAllScalarFields()))))
+		.WithBuyFor(new ItemPriceQueryBuilder().WithAllScalarFields()
+			.WithVendor(new VendorQueryBuilder().WithAllScalarFields()
+				.WithTraderOfferFragment(new TraderOfferQueryBuilder().WithAllScalarFields()
+					.WithTrader(new TraderQueryBuilder().WithAllScalarFields()))))
+		.WithCategory(new ItemCategoryQueryBuilder().WithAllScalarFields())
+		.WithCategories(new ItemCategoryQueryBuilder().WithAllScalarFields())
+		.WithUsedInTasks(new TaskQueryBuilder().WithId())
+		.WithReceivedFromTasks(new TaskQueryBuilder().WithId())
+		.WithBartersFor(new BarterQueryBuilder().WithId())
+		.WithBartersUsing(new BarterQueryBuilder().WithId())
+		.WithCraftsFor(new CraftQueryBuilder().WithId())
+		.WithCraftsUsing(new CraftQueryBuilder().WithId())
+		.WithTypes()
+		, alias: "data", lang: language, gameMode: gameMode).Build();
 	}
 
 	#endregion
@@ -392,64 +379,53 @@ public static class TarkovDevAPI {
 
 	private static string TasksQuery() => TasksQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string TasksQuery(LanguageCode language, GameMode gameMode) {
-		string lang = ToGraphQlEnum(language);
-		string mode = ToGraphQlEnum(gameMode);
-		return $@"query {{
-  data: tasks(lang: {lang}, gameMode: {mode}) {{
-    id
-    name
-    taskImageLink
-    wikiLink
-    kappaRequired
-    trader {{
-      name
-      imageLink
-    }}
-    objectives {{
-      __typename
-      id
-      type
-      description
-      ... on TaskObjectiveItem {{
-        count
-        foundInRaid
-        items {{ id }}
-        zones {{
-          map {{ id }}
-          position {{ x y z }}
-        }}
-      }}
-      ... on TaskObjectiveMark {{
-        markerItem {{ id }}
-        zones {{
-          map {{ id }}
-          position {{ x y z }}
-        }}
-      }}
-      ... on TaskObjectiveBuildItem {{
-        item {{ id }}
-      }}
-      ... on TaskObjectiveBasic {{
-        zones {{
-          map {{ id }}
-          position {{ x y z }}
-        }}
-      }}
-      ... on TaskObjectiveQuestItem {{
-        zones {{
-          map {{ id }}
-          position {{ x y z }}
-        }}
-      }}
-      ... on TaskObjectiveUseItem {{
-        zones {{
-          map {{ id }}
-          position {{ x y z }}
-        }}
-      }}
-    }}
-  }}
-}}";
+		return new QueryQueryBuilder().WithTasks(new TaskQueryBuilder().WithAllScalarFields()
+			.WithKappaRequired()
+			.WithMap(new MapQueryBuilder().WithAllScalarFields())
+			.WithTrader(new TraderQueryBuilder().WithAllScalarFields())
+			.WithObjectives(new TaskObjectiveQueryBuilder().WithAllScalarFields()
+				.WithTaskObjectiveBasicFragment(new TaskObjectiveBasicQueryBuilder().WithAllScalarFields()
+					.WithZones(new TaskZoneQueryBuilder().WithMap(new MapQueryBuilder().WithId()).WithPosition(new MapPositionQueryBuilder().WithAllScalarFields())))
+
+				.WithTaskObjectiveBuildItemFragment(new TaskObjectiveBuildItemQueryBuilder().WithAllScalarFields()
+					.WithItem(new ItemQueryBuilder().WithAllScalarFields()))
+
+				.WithTaskObjectiveExperienceFragment(new TaskObjectiveExperienceQueryBuilder().WithAllScalarFields())
+
+				.WithTaskObjectiveExtractFragment(new TaskObjectiveExtractQueryBuilder().WithAllScalarFields())
+
+				.WithTaskObjectiveItemFragment(new TaskObjectiveItemQueryBuilder().WithAllScalarFields()
+					.WithZones(new TaskZoneQueryBuilder().WithMap(new MapQueryBuilder().WithId()).WithPosition(new MapPositionQueryBuilder().WithAllScalarFields()))
+					.WithItems(new ItemQueryBuilder().WithAllScalarFields()))
+
+				.WithTaskObjectiveMarkFragment(new TaskObjectiveMarkQueryBuilder().WithAllScalarFields()
+					.WithZones(new TaskZoneQueryBuilder().WithMap(new MapQueryBuilder().WithId()).WithPosition(new MapPositionQueryBuilder().WithAllScalarFields()))
+					.WithMarkerItem(new ItemQueryBuilder().WithAllScalarFields()))
+
+				.WithTaskObjectivePlayerLevelFragment(new TaskObjectivePlayerLevelQueryBuilder().WithAllScalarFields())
+
+				.WithTaskObjectiveQuestItemFragment(new TaskObjectiveQuestItemQueryBuilder().WithAllScalarFields()
+					.WithZones(new TaskZoneQueryBuilder().WithMap(new MapQueryBuilder().WithId()).WithPosition(new MapPositionQueryBuilder().WithAllScalarFields()))
+					.WithQuestItem(new QuestItemQueryBuilder().WithAllScalarFields()))
+
+				.WithTaskObjectiveShootFragment(new TaskObjectiveShootQueryBuilder().WithAllScalarFields())
+
+				.WithTaskObjectiveSkillFragment(new TaskObjectiveSkillQueryBuilder().WithAllScalarFields())
+
+				.WithTaskObjectiveTaskStatusFragment(new TaskObjectiveTaskStatusQueryBuilder().WithAllScalarFields())
+
+				.WithTaskObjectiveTraderLevelFragment(new TaskObjectiveTraderLevelQueryBuilder().WithAllScalarFields()
+					.WithTrader(new TraderQueryBuilder().WithAllScalarFields()))
+
+				.WithTaskObjectiveTraderStandingFragment(new TaskObjectiveTraderStandingQueryBuilder().WithAllScalarFields()
+					.WithTrader(new TraderQueryBuilder().WithAllScalarFields()))
+
+				.WithTaskObjectiveUseItemFragment(new TaskObjectiveUseItemQueryBuilder().WithAllScalarFields()
+					.WithZones(new TaskZoneQueryBuilder().WithMap(new MapQueryBuilder().WithId()).WithPosition(new MapPositionQueryBuilder().WithAllScalarFields()))
+					.WithUseAny(new ItemQueryBuilder().WithAllScalarFields())))
+			.WithTaskRequirements(new TaskStatusRequirementQueryBuilder().WithAllScalarFields()
+				.WithTask(new TaskQueryBuilder().WithAllScalarFields()))
+		, alias: "data", lang: language, gameMode: gameMode).Build();
 	}
 
 	#endregion
@@ -461,20 +437,18 @@ public static class TarkovDevAPI {
 
 	private static string HideoutStationsQuery() => HideoutStationsQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string HideoutStationsQuery(LanguageCode language, GameMode gameMode) {
-		string lang = ToGraphQlEnum(language);
-		string mode = ToGraphQlEnum(gameMode);
-		return $@"query {{
-  data: hideoutStations(lang: {lang}, gameMode: {mode}) {{
-    levels {{
-      id
-      itemRequirements {{
-        id
-        count
-        item {{ id }}
-      }}
-    }}
-  }}
-}}";
+		return new QueryQueryBuilder().WithHideoutStations(new HideoutStationQueryBuilder().WithAllScalarFields()
+			.WithLevels(new HideoutStationLevelQueryBuilder().WithAllScalarFields()
+				.WithItemRequirements(new RequirementItemQueryBuilder().WithAllScalarFields()
+					.WithItem(new ItemQueryBuilder().WithAllScalarFields()))
+				.WithStationLevelRequirements(new RequirementHideoutStationLevelQueryBuilder().WithAllScalarFields()
+					.WithStation(new HideoutStationQueryBuilder().WithAllScalarFields()))
+				.WithCrafts(new CraftQueryBuilder().WithAllScalarFields()
+					.WithRequiredItems(new ContainedItemQueryBuilder().WithAllScalarFields()
+						.WithItem(new ItemQueryBuilder().WithAllScalarFields()))
+					.WithRewardItems(new ContainedItemQueryBuilder().WithAllScalarFields()
+						.WithItem(new ItemQueryBuilder().WithAllScalarFields()))))
+		, alias: "data", lang: language, gameMode: gameMode).Build();
 	}
 
 	#endregion
@@ -486,18 +460,15 @@ public static class TarkovDevAPI {
 
 	private static string MapsQuery() => MapsQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string MapsQuery(LanguageCode language, GameMode gameMode) {
-		string lang = ToGraphQlEnum(language);
-		string mode = ToGraphQlEnum(gameMode);
-		return $@"query {{
-  data: maps(lang: {lang}, gameMode: {mode}) {{
-    id
-    name
-    normalizedName
-  }}
-}}";
+		return new QueryQueryBuilder().WithMaps(new MapQueryBuilder().WithAllScalarFields()
+			.WithExtracts(new MapExtractQueryBuilder().WithAllScalarFields()
+				.WithPosition(new MapPositionQueryBuilder().WithAllScalarFields())
+				.WithTransferItem(new ContainedItemQueryBuilder().WithAllScalarFields()
+					.WithItem(new ItemQueryBuilder().WithId())))
+			.WithTransits(new MapTransitQueryBuilder().WithAllScalarFields()
+				.WithPosition(new MapPositionQueryBuilder().WithAllScalarFields()))
+		, alias: "data", lang: language, gameMode: gameMode).Build();
 	}
 
 	#endregion
-
-	private static string ToGraphQlEnum(Enum value) => value.ToString().ToLowerInvariant();
 }

--- a/RatScanner/TarkovDevAPI.cs
+++ b/RatScanner/TarkovDevAPI.cs
@@ -1,11 +1,10 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using RatScanner.TarkovDev.GraphQL;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -18,23 +17,44 @@ namespace RatScanner;
 public static class TarkovDevAPI {
 	private class ResponseData<T> {
 		[JsonProperty("data")]
-		public ResponseDataInner<T> Data { get; set; }
+		public ResponseDataInner<T>? Data { get; set; }
 	}
 
 	private class ResponseDataInner<T> {
 		[JsonProperty("data")]
-		public T Data { get; set; }
+		public T? Data { get; set; }
+	}
+
+	private sealed class RateLimitedException : Exception {
+		public TimeSpan? RetryAfter { get; }
+
+		public RateLimitedException(TimeSpan? retryAfter, string message) : base(message) {
+			RetryAfter = retryAfter;
+		}
 	}
 
 	const string ApiEndpoint = "https://api.tarkov.dev/graphql";
-	const int BatchSize = 200;
 
 	private static readonly ConcurrentDictionary<string, (long expire, object response)> Cache = new();
-	private static readonly ConcurrentDictionary<string, bool> PendingRequests = new();
+	private static readonly ConcurrentDictionary<string, Lazy<Task>> InFlightRequests = new();
+	private static readonly ConcurrentDictionary<string, long> BackoffUntil = new();
 
-	private static readonly HttpClient HttpClient = new(new HttpClientHandler {
-		AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-	});
+	private static readonly HttpClient HttpClient = CreateHttpClient();
+
+	private static HttpClient CreateHttpClient() {
+		HttpClient client = new(new HttpClientHandler {
+			AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli,
+		});
+		client.Timeout = TimeSpan.FromSeconds(30);
+		// Some upstreams reject requests without a user-agent.
+		try {
+			client.DefaultRequestHeaders.UserAgent.ParseAdd($"RatScanner/{RatConfig.Version}");
+		} catch (Exception e) {
+			Logger.LogWarning("Failed to set user-agent header; falling back to default RatScanner user-agent.", e);
+			client.DefaultRequestHeaders.UserAgent.ParseAdd("RatScanner");
+		}
+		return client;
+	}
 
 	private static readonly JsonSerializerSettings JsonSettings = new() {
 		MissingMemberHandling = MissingMemberHandling.Ignore,
@@ -43,12 +63,33 @@ public static class TarkovDevAPI {
 		TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
 	};
 
-	private static async Task<Stream> Get(string query) {
+	private static async Task<string> GetResponseString(string query) {
 		Dictionary<string, string> body = new() { { "query", query } };
-		HttpResponseMessage responseTask = await HttpClient.PostAsJsonAsync(ApiEndpoint, body);
+		using HttpResponseMessage response = await HttpClient.PostAsJsonAsync(ApiEndpoint, body).ConfigureAwait(false);
 
-		if (responseTask.StatusCode != HttpStatusCode.OK) throw new Exception($"Tarkov.dev API request failed. {responseTask.ReasonPhrase}");
-		return await responseTask.Content.ReadAsStreamAsync();
+		string responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+		if (response.StatusCode == HttpStatusCode.TooManyRequests) {
+			string trimmed = responseBody;
+			if (trimmed.Length > 512) trimmed = trimmed.Substring(0, 512) + "...";
+			throw new RateLimitedException(GetRetryAfter(response), $"Tarkov.dev API rate limited (429). Body: {trimmed}");
+		}
+		if (response.StatusCode != HttpStatusCode.OK) {
+			string trimmed = responseBody;
+			if (trimmed.Length > 512) trimmed = trimmed.Substring(0, 512) + "...";
+			throw new Exception($"Tarkov.dev API request failed ({(int)response.StatusCode} {response.ReasonPhrase}). Body: {trimmed}");
+		}
+		return responseBody;
+	}
+
+	private static TimeSpan? GetRetryAfter(HttpResponseMessage response) {
+		if (response.Headers.RetryAfter?.Delta != null) {
+			return response.Headers.RetryAfter.Delta;
+		}
+		if (response.Headers.RetryAfter?.Date != null) {
+			TimeSpan delta = response.Headers.RetryAfter.Date.Value - DateTimeOffset.UtcNow;
+			return delta < TimeSpan.Zero ? TimeSpan.Zero : delta;
+		}
+		return null;
 	}
 
 	/// <summary>
@@ -58,13 +99,19 @@ public static class TarkovDevAPI {
 	private static bool TryLoadFromOfflineCache<T>(string baseQueryKey, long ttl) where T : class {
 		if (Cache.ContainsKey(baseQueryKey)) return true;
 
-		if (RatConfig.ReadFromCache(baseQueryKey, out string cachedResponse)) {
+		if (RatConfig.ReadFromCache(baseQueryKey, out string cachedResponse, out DateTimeOffset lastWriteUtc)) {
 			try {
 				ResponseData<T[]>? neededResponse = JsonConvert.DeserializeObject<ResponseData<T[]>?>(cachedResponse, JsonSettings);
 				if (neededResponse?.Data?.Data != null) {
 					long time = DateTimeOffset.Now.ToUnixTimeSeconds();
-					// Use expired TTL so background refresh will be triggered
-					Cache[baseQueryKey] = (time - 1, neededResponse.Data.Data);
+					long expire = time - 1;
+					if (ttl > 0 && lastWriteUtc != DateTimeOffset.MinValue) {
+						long ageSeconds = Math.Max(0, (long)(DateTimeOffset.UtcNow - lastWriteUtc).TotalSeconds);
+						if (ageSeconds < ttl) {
+							expire = time + (ttl - ageSeconds);
+						}
+					}
+					Cache[baseQueryKey] = (expire, neededResponse.Data.Data);
 					Logger.LogInfo($"Loaded {neededResponse.Data.Data.Length} items from offline cache for: \"{baseQueryKey}\"");
 					return true;
 				}
@@ -76,66 +123,48 @@ public static class TarkovDevAPI {
 	}
 
 	/// <summary>
-	/// Fetches paginated data in batches and combines results
+	/// Fetches all data in a single request
 	/// </summary>
-	private static async Task QueuePaginatedRequest<T>(string baseQueryKey, Func<int, int, string> queryBuilder, long ttl) where T : class {
-		// Check if request is already pending
-		if (!PendingRequests.TryAdd(baseQueryKey, true)) {
-			Logger.LogInfo($"Request already pending for: \"{baseQueryKey}\", skipping");
-			return;
-		}
-
+	private static async Task QueueRequestInternal<T>(string baseQueryKey, Func<string> queryBuilder, long ttl) where T : class {
 		try {
-			List<T> allResults = new();
-			List<string> rawBatchResponses = new();
-			int offset = 0;
-			bool hasMore = true;
-
 			Stopwatch sw = Stopwatch.StartNew();
+			string query = queryBuilder();
+			Logger.LogInfo($"Fetching data for: \"{baseQueryKey}\"");
 
-			while (hasMore) {
-				string query = queryBuilder(BatchSize, offset);
-				Logger.LogInfo($"Fetching batch at offset {offset} for: \"{baseQueryKey}\"");
+			// Read raw response for caching
+			string rawResponse = await GetResponseString(query).ConfigureAwait(false);
 
-				using Stream stream = await Get(query);
-				using StreamReader streamReader = new(stream);
-				
-				// Read raw response for caching
-				string rawResponse = await streamReader.ReadToEndAsync();
-				rawBatchResponses.Add(rawResponse);
-				
-				// Parse the response
-				ResponseData<T[]>? neededResponse = JsonConvert.DeserializeObject<ResponseData<T[]>>(rawResponse, JsonSettings);
-				if (neededResponse?.Data?.Data == null) throw new Exception("Failed to deserialize paginated response");
+			// Parse the response
+			ResponseData<T[]>? neededResponse = JsonConvert.DeserializeObject<ResponseData<T[]>>(rawResponse, JsonSettings);
+			if (neededResponse?.Data?.Data == null) throw new Exception("Failed to deserialize response");
 
-				T[] batchResults = neededResponse.Data.Data;
-				allResults.AddRange(batchResults);
+			T[] results = neededResponse.Data.Data;
 
-				Logger.LogInfo($"Fetched {batchResults.Length} items at offset {offset} for: \"{baseQueryKey}\"");
-
-				// If we got less than BatchSize, we've reached the end
-				hasMore = batchResults.Length >= BatchSize;
-				offset += BatchSize;
-			}
-
-			// Store combined results in cache
+			// Store results in cache
 			long time = DateTimeOffset.Now.ToUnixTimeSeconds();
-			T[] finalResults = allResults.ToArray();
-			Cache[baseQueryKey] = (time + ttl, finalResults);
+			Cache[baseQueryKey] = (time + ttl, results);
+			BackoffUntil.TryRemove(baseQueryKey, out _);
 
-			// Combine raw responses for cache - extract and merge the data arrays
-			string combinedCacheJson = CombineRawResponses<T>(rawBatchResponses);
-			RatConfig.WriteToCache(baseQueryKey, combinedCacheJson);
+			// Cache raw response for offline use
+			RatConfig.WriteToCache(baseQueryKey, rawResponse);
 
-			Logger.LogInfo($"Completed paginated fetch in {sw.ElapsedMilliseconds}ms: {allResults.Count} total items for \"{baseQueryKey}\"");
+			Logger.LogInfo($"Completed fetch in {sw.ElapsedMilliseconds}ms: {results.Length} total items for \"{baseQueryKey}\"");
 		} catch (Exception e) {
-			Logger.LogWarning($"Failed paginated request for: \"{baseQueryKey}\".", e);
+			Logger.LogWarning($"Failed request for: \"{baseQueryKey}\".", e);
+
+			if (e is RateLimitedException rateLimited) {
+				ApplyBackoff(baseQueryKey, rateLimited.RetryAfter);
+			}
 
 			// If we have existing cached data, extend its TTL to prevent rapid retries
 			if (Cache.TryGetValue(baseQueryKey, out var existingCache))
 			{
 				long time = DateTimeOffset.Now.ToUnixTimeSeconds();
-				Cache[baseQueryKey] = (time + RatConfig.SuperShortTTL, existingCache.response);
+				long expire = time + RatConfig.SuperShortTTL;
+				if (BackoffUntil.TryGetValue(baseQueryKey, out long until)) {
+					expire = Math.Max(expire, until);
+				}
+				Cache[baseQueryKey] = (expire, existingCache.response);
 				Logger.LogInfo($"Extended cache TTL for: \"{baseQueryKey}\" to prevent rapid retries");
 				return;
 			}
@@ -147,58 +176,92 @@ public static class TarkovDevAPI {
 				ResponseData<T[]>? neededResponse = JsonConvert.DeserializeObject<ResponseData<T[]>?>(cachedResponse, JsonSettings);
 				if (neededResponse?.Data?.Data != null) {
 					long time = DateTimeOffset.Now.ToUnixTimeSeconds();
-					Cache[baseQueryKey] = (time + RatConfig.SuperShortTTL, neededResponse.Data.Data);
+					long expire = time + RatConfig.SuperShortTTL;
+					if (BackoffUntil.TryGetValue(baseQueryKey, out long until)) {
+						expire = Math.Max(expire, until);
+					}
+					Cache[baseQueryKey] = (expire, neededResponse.Data.Data);
 					return;
 				}
 			}
 
-			if (!Cache.ContainsKey(baseQueryKey)) throw new Exception("Failed to fetch paginated query response and no cache available.");
-		} finally {
-			// Always remove from pending requests when done
-			PendingRequests.TryRemove(baseQueryKey, out _);
+			if (!Cache.ContainsKey(baseQueryKey)) {
+				throw new Exception("Failed to fetch query response and no cache available.");
+			}
 		}
 	}
 
-	/// <summary>
-	/// Combines multiple raw JSON responses into a single cached response, preserving __typename fields
-	/// </summary>
-	private static string CombineRawResponses<T>(List<string> rawResponses) where T : class {
-		List<Newtonsoft.Json.Linq.JToken> allDataItems = new();
-
-		foreach (string rawResponse in rawResponses) {
-			var json = Newtonsoft.Json.Linq.JObject.Parse(rawResponse);
-			var dataArray = json["data"]?["data"] as Newtonsoft.Json.Linq.JArray;
-			if (dataArray != null) {
-				allDataItems.AddRange(dataArray);
-			}
+	private static Task QueueRequest<T>(string baseQueryKey, Func<string> queryBuilder, long ttl) where T : class {
+		if (InFlightRequests.TryGetValue(baseQueryKey, out Lazy<Task> existingLazy)) {
+			return existingLazy.Value;
+		}
+		if (IsInBackoff(baseQueryKey)) {
+			return Task.CompletedTask;
 		}
 
-		// Create combined response structure
-		var combined = new Newtonsoft.Json.Linq.JObject {
-			["data"] = new Newtonsoft.Json.Linq.JObject {
-				["data"] = new Newtonsoft.Json.Linq.JArray(allDataItems)
-			}
-		};
-
-		return combined.ToString(Newtonsoft.Json.Formatting.None);
+		Lazy<Task> newLazy = new(() => QueueRequestInternal<T>(baseQueryKey, queryBuilder, ttl));
+		Lazy<Task> lazy = InFlightRequests.GetOrAdd(baseQueryKey, newLazy);
+		Task task = lazy.Value;
+		if (lazy == newLazy) {
+			_ = task.ContinueWith(_ => InFlightRequests.TryRemove(baseQueryKey, out Lazy<Task> _), TaskScheduler.Default);
+		}
+		return task;
 	}
 
-	private static T[] GetCachedPaginated<T>(string baseQueryKey, Func<int, int, string> queryBuilder, long ttl, bool isRetry = false) where T : class {
-		if (!Cache.TryGetValue(baseQueryKey, out (long expire, object response) value)) {
-			if (isRetry) throw new Exception("Retrying to fetch paginated query response failed.");
+	private static T[] GetCached<T>(string baseQueryKey, Func<string> queryBuilder, long ttl) where T : class {
+		try {
+			if (!Cache.TryGetValue(baseQueryKey, out (long expire, object response) value)) {
+				if (IsInBackoff(baseQueryKey)) {
+					return Array.Empty<T>();
+				}
+				if (InFlightRequests.ContainsKey(baseQueryKey)) {
+					return Array.Empty<T>();
+				}
 
-			Logger.LogInfo($"Paginated query not found in cache: \"{baseQueryKey}\"");
-			Task.Run(() => QueuePaginatedRequest<T>(baseQueryKey, queryBuilder, ttl)).Wait();
-			return GetCachedPaginated<T>(baseQueryKey, queryBuilder, ttl, true);
+				Logger.LogInfo($"Cache miss for: \"{baseQueryKey}\", queuing fetch.");
+				try {
+					_ = QueueRequest<T>(baseQueryKey, queryBuilder, ttl);
+				} catch (Exception e) {
+					Logger.LogWarning($"Failed to queue request for: \"{baseQueryKey}\", returning empty.", e);
+				}
+				return Array.Empty<T>();
+			}
+
+			// Queue request if cache is expired and no request is already pending
+			long time = DateTimeOffset.Now.ToUnixTimeSeconds();
+			if (time > value.expire && !IsInBackoff(baseQueryKey) && !InFlightRequests.ContainsKey(baseQueryKey)) {
+				_ = QueueRequest<T>(baseQueryKey, queryBuilder, ttl);
+			}
+
+			return (T[])value.response;
+		} catch (Exception e) {
+			Logger.LogWarning($"Failed to get cached data for: \"{baseQueryKey}\", returning empty.", e);
+			return Array.Empty<T>();
 		}
+	}
 
-		// Queue request if cache is expired and no request is already pending
+	private static bool IsInBackoff(string baseQueryKey) {
 		long time = DateTimeOffset.Now.ToUnixTimeSeconds();
-		if (time > value.expire && !PendingRequests.ContainsKey(baseQueryKey)) {
-			Task.Run(() => QueuePaginatedRequest<T>(baseQueryKey, queryBuilder, ttl));
+		if (BackoffUntil.TryGetValue(baseQueryKey, out long until)) {
+			if (until > time) {
+				return true;
+			}
+			BackoffUntil.TryRemove(baseQueryKey, out _);
 		}
+		return false;
+	}
 
-		return (T[])value.response;
+	private static void ApplyBackoff(string baseQueryKey, TimeSpan? retryAfter) {
+		double delaySeconds = retryAfter?.TotalSeconds ?? RatConfig.SuperShortTTL;
+		long backoffSeconds = (long)Math.Ceiling(Math.Max(delaySeconds, RatConfig.SuperShortTTL));
+		long time = DateTimeOffset.Now.ToUnixTimeSeconds();
+		long until = time + backoffSeconds;
+		BackoffUntil[baseQueryKey] = until;
+
+		if (Cache.TryGetValue(baseQueryKey, out var existingCache)) {
+			Cache[baseQueryKey] = (Math.Max(existingCache.expire, until), existingCache.response);
+		}
+		Logger.LogInfo($"Rate limited for: \"{baseQueryKey}\". Backing off for {backoffSeconds}s.");
 	}
 
 	/// <summary>
@@ -224,64 +287,100 @@ public static class TarkovDevAPI {
 		return allLoaded;
 	}
 
+	internal static bool AnyCacheExpired() {
+		long time = DateTimeOffset.Now.ToUnixTimeSeconds();
+		return IsCacheExpired(ItemsQueryKey(), time)
+			|| IsCacheExpired(TasksQueryKey(), time)
+			|| IsCacheExpired(HideoutStationsQueryKey(), time)
+			|| IsCacheExpired(MapsQueryKey(), time);
+	}
+
+	private static bool IsCacheExpired(string baseQueryKey, long time) {
+		if (!Cache.TryGetValue(baseQueryKey, out (long expire, object response) cached)) {
+			return true;
+		}
+		return time > cached.expire;
+	}
+
 	/// <summary>
 	/// Full cache initialization - waits for all requests to complete
 	/// </summary>
 	public static async Task InitializeCache() {
 		await Task.WhenAll(
-			Task.Run(() => QueuePaginatedRequest<Item>(ItemsQueryKey(), ItemsQueryPaginated, RatConfig.MediumTTL)),
-			Task.Run(() => QueuePaginatedRequest<TTask>(TasksQueryKey(), TasksQueryPaginated, RatConfig.LongTTL)),
-			Task.Run(() => QueuePaginatedRequest<HideoutStation>(HideoutStationsQueryKey(), HideoutStationsQueryPaginated, RatConfig.LongTTL)),
-			Task.Run(() => QueuePaginatedRequest<Map>(MapsQueryKey(), MapsQueryPaginated, RatConfig.LongTTL))
+			QueueRequest<Item>(ItemsQueryKey(), ItemsQuery, RatConfig.MediumTTL),
+			QueueRequest<TTask>(TasksQueryKey(), TasksQuery, RatConfig.LongTTL),
+			QueueRequest<HideoutStation>(HideoutStationsQueryKey(), HideoutStationsQuery, RatConfig.LongTTL),
+			QueueRequest<Map>(MapsQueryKey(), MapsQuery, RatConfig.LongTTL)
 		).ConfigureAwait(false);
 	}
 
-	public static Item[] GetItems(LanguageCode language, GameMode gameMode) => GetCachedPaginated<Item>(ItemsQueryKey(language, gameMode), (limit, offset) => ItemsQueryPaginated(limit, offset, language, gameMode), RatConfig.MediumTTL);
-	public static Item[] GetItems() => GetCachedPaginated<Item>(ItemsQueryKey(), ItemsQueryPaginated, RatConfig.MediumTTL);
+	public static Item[] GetItems(LanguageCode language, GameMode gameMode) => GetCached<Item>(ItemsQueryKey(language, gameMode), () => ItemsQuery(language, gameMode), RatConfig.MediumTTL);
+	public static Item[] GetItems() => GetCached<Item>(ItemsQueryKey(), ItemsQuery, RatConfig.MediumTTL);
+	public static bool TryGetCachedItems(out Item[] items) {
+		if (Cache.TryGetValue(ItemsQueryKey(), out (long expire, object response) cached)) {
+			items = (Item[])cached.response;
+			return true;
+		}
+		items = Array.Empty<Item>();
+		return false;
+	}
 
-	public static TTask[] GetTasks(LanguageCode language, GameMode gameMode) => GetCachedPaginated<TTask>(TasksQueryKey(language, gameMode), (limit, offset) => TasksQueryPaginated(limit, offset, language, gameMode), RatConfig.LongTTL);
-	public static TTask[] GetTasks() => GetCachedPaginated<TTask>(TasksQueryKey(), TasksQueryPaginated, RatConfig.LongTTL);
+	public static TTask[] GetTasks(LanguageCode language, GameMode gameMode) => GetCached<TTask>(TasksQueryKey(language, gameMode), () => TasksQuery(language, gameMode), RatConfig.LongTTL);
+	public static TTask[] GetTasks() => GetCached<TTask>(TasksQueryKey(), TasksQuery, RatConfig.LongTTL);
 
-	public static HideoutStation[] GetHideoutStations(LanguageCode language, GameMode gameMode) => GetCachedPaginated<HideoutStation>(HideoutStationsQueryKey(language, gameMode), (limit, offset) => HideoutStationsQueryPaginated(limit, offset, language, gameMode), RatConfig.LongTTL);
-	public static HideoutStation[] GetHideoutStations() => GetCachedPaginated<HideoutStation>(HideoutStationsQueryKey(), HideoutStationsQueryPaginated, RatConfig.LongTTL);
+	public static HideoutStation[] GetHideoutStations(LanguageCode language, GameMode gameMode) => GetCached<HideoutStation>(HideoutStationsQueryKey(language, gameMode), () => HideoutStationsQuery(language, gameMode), RatConfig.LongTTL);
+	public static HideoutStation[] GetHideoutStations() => GetCached<HideoutStation>(HideoutStationsQueryKey(), HideoutStationsQuery, RatConfig.LongTTL);
 
-	public static Map[] GetMaps(LanguageCode language, GameMode gameMode) => GetCachedPaginated<Map>(MapsQueryKey(language, gameMode), (limit, offset) => MapsQueryPaginated(limit, offset, language, gameMode), RatConfig.LongTTL);
-	public static Map[] GetMaps() => GetCachedPaginated<Map>(MapsQueryKey(), MapsQueryPaginated, RatConfig.LongTTL);
+	public static Map[] GetMaps(LanguageCode language, GameMode gameMode) => GetCached<Map>(MapsQueryKey(language, gameMode), () => MapsQuery(language, gameMode), RatConfig.LongTTL);
+	public static Map[] GetMaps() => GetCached<Map>(MapsQueryKey(), MapsQuery, RatConfig.LongTTL);
 
 	#region Items Query
 
 	private static string ItemsQueryKey() => ItemsQueryKey(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string ItemsQueryKey(LanguageCode language, GameMode gameMode) => $"items_{language}_{gameMode}";
 
-	private static string ItemsQueryPaginated(int limit, int offset) => ItemsQueryPaginated(limit, offset, RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
-	private static string ItemsQueryPaginated(int limit, int offset, LanguageCode language, GameMode gameMode) {
-		return new QueryQueryBuilder().WithItems(new ItemQueryBuilder().WithAllScalarFields()
-		.WithProperties(new ItemPropertiesQueryBuilder().WithAllScalarFields()
-			.WithItemPropertiesAmmoFragment(new ItemPropertiesAmmoQueryBuilder().WithAllScalarFields())
-			.WithItemPropertiesFoodDrinkFragment(new ItemPropertiesFoodDrinkQueryBuilder().WithAllScalarFields()
-				.WithStimEffects(new StimEffectQueryBuilder().WithAllScalarFields()))
-			.WithItemPropertiesStimFragment(new ItemPropertiesStimQueryBuilder().WithAllScalarFields()
-				.WithStimEffects(new StimEffectQueryBuilder().WithAllScalarFields()))
-			.WithItemPropertiesMedicalItemFragment(new ItemPropertiesMedicalItemQueryBuilder().WithAllScalarFields())
-			.WithItemPropertiesMedKitFragment(new ItemPropertiesMedKitQueryBuilder().WithAllScalarFields()))
-		.WithSellFor(new ItemPriceQueryBuilder().WithAllScalarFields()
-			.WithVendor(new VendorQueryBuilder().WithAllScalarFields()
-				.WithTraderOfferFragment(new TraderOfferQueryBuilder().WithAllScalarFields()
-					.WithTrader(new TraderQueryBuilder().WithAllScalarFields()))))
-		.WithBuyFor(new ItemPriceQueryBuilder().WithAllScalarFields()
-			.WithVendor(new VendorQueryBuilder().WithAllScalarFields()
-				.WithTraderOfferFragment(new TraderOfferQueryBuilder().WithAllScalarFields()
-					.WithTrader(new TraderQueryBuilder().WithAllScalarFields()))))
-		.WithCategory(new ItemCategoryQueryBuilder().WithAllScalarFields())
-		.WithCategories(new ItemCategoryQueryBuilder().WithAllScalarFields())
-		.WithUsedInTasks(new TaskQueryBuilder().WithId())
-		.WithReceivedFromTasks(new TaskQueryBuilder().WithId())
-		.WithBartersFor(new BarterQueryBuilder().WithId())
-		.WithBartersUsing(new BarterQueryBuilder().WithId())
-		.WithCraftsFor(new CraftQueryBuilder().WithId())
-		.WithCraftsUsing(new CraftQueryBuilder().WithId())
-		.WithTypes()
-		, alias: "data", lang: language, gameMode: gameMode, limit: limit, offset: offset).Build();
+	private static string ItemsQuery() => ItemsQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
+	private static string ItemsQuery(LanguageCode language, GameMode gameMode) {
+		string lang = ToGraphQlEnum(language);
+		string mode = ToGraphQlEnum(gameMode);
+		return $@"query {{
+  data: items(lang: {lang}, gameMode: {mode}) {{
+    id
+    name
+    shortName
+    iconLink
+    baseImageLink
+    link
+    wikiLink
+    avg24hPrice
+    width
+    height
+    updated
+    types
+    properties {{
+      __typename
+      ... on ItemPropertiesAmmo {{
+        caliber
+        damage
+        penetrationPower
+        fragmentationChance
+      }}
+    }}
+    sellFor {{
+      priceRUB
+      vendor {{
+        __typename
+        ... on TraderOffer {{
+          name
+          trader {{
+            name
+            imageLink
+          }}
+        }}
+      }}
+    }}
+  }}
+}}";
 	}
 
 	#endregion
@@ -291,55 +390,66 @@ public static class TarkovDevAPI {
 	private static string TasksQueryKey() => TasksQueryKey(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string TasksQueryKey(LanguageCode language, GameMode gameMode) => $"tasks_{language}_{gameMode}";
 
-	private static string TasksQueryPaginated(int limit, int offset) => TasksQueryPaginated(limit, offset, RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
-	private static string TasksQueryPaginated(int limit, int offset, LanguageCode language, GameMode gameMode) {
-		return new QueryQueryBuilder().WithTasks(new TaskQueryBuilder().WithAllScalarFields()
-			.WithKappaRequired()
-			.WithMap(new MapQueryBuilder().WithAllScalarFields())
-			.WithTrader(new TraderQueryBuilder().WithAllScalarFields())
-			.WithObjectives(new TaskObjectiveQueryBuilder().WithAllScalarFields()
-				.WithTaskObjectiveBasicFragment(new TaskObjectiveBasicQueryBuilder().WithAllScalarFields()
-					.WithZones(new TaskZoneQueryBuilder().WithMap(new MapQueryBuilder().WithId()).WithPosition(new MapPositionQueryBuilder().WithAllScalarFields())))
-
-				.WithTaskObjectiveBuildItemFragment(new TaskObjectiveBuildItemQueryBuilder().WithAllScalarFields()
-					.WithItem(new ItemQueryBuilder().WithAllScalarFields()))
-
-				.WithTaskObjectiveExperienceFragment(new TaskObjectiveExperienceQueryBuilder().WithAllScalarFields())
-
-				.WithTaskObjectiveExtractFragment(new TaskObjectiveExtractQueryBuilder().WithAllScalarFields())
-
-				.WithTaskObjectiveItemFragment(new TaskObjectiveItemQueryBuilder().WithAllScalarFields()
-					.WithZones(new TaskZoneQueryBuilder().WithMap(new MapQueryBuilder().WithId()).WithPosition(new MapPositionQueryBuilder().WithAllScalarFields()))
-					.WithItems(new ItemQueryBuilder().WithAllScalarFields()))
-
-				.WithTaskObjectiveMarkFragment(new TaskObjectiveMarkQueryBuilder().WithAllScalarFields()
-					.WithZones(new TaskZoneQueryBuilder().WithMap(new MapQueryBuilder().WithId()).WithPosition(new MapPositionQueryBuilder().WithAllScalarFields()))
-					.WithMarkerItem(new ItemQueryBuilder().WithAllScalarFields()))
-
-				.WithTaskObjectivePlayerLevelFragment(new TaskObjectivePlayerLevelQueryBuilder().WithAllScalarFields())
-
-				.WithTaskObjectiveQuestItemFragment(new TaskObjectiveQuestItemQueryBuilder().WithAllScalarFields()
-					.WithZones(new TaskZoneQueryBuilder().WithMap(new MapQueryBuilder().WithId()).WithPosition(new MapPositionQueryBuilder().WithAllScalarFields()))
-					.WithQuestItem(new QuestItemQueryBuilder().WithAllScalarFields()))
-
-				.WithTaskObjectiveShootFragment(new TaskObjectiveShootQueryBuilder().WithAllScalarFields())
-
-				.WithTaskObjectiveSkillFragment(new TaskObjectiveSkillQueryBuilder().WithAllScalarFields())
-
-				.WithTaskObjectiveTaskStatusFragment(new TaskObjectiveTaskStatusQueryBuilder().WithAllScalarFields())
-
-				.WithTaskObjectiveTraderLevelFragment(new TaskObjectiveTraderLevelQueryBuilder().WithAllScalarFields()
-					.WithTrader(new TraderQueryBuilder().WithAllScalarFields()))
-
-				.WithTaskObjectiveTraderStandingFragment(new TaskObjectiveTraderStandingQueryBuilder().WithAllScalarFields()
-					.WithTrader(new TraderQueryBuilder().WithAllScalarFields()))
-
-				.WithTaskObjectiveUseItemFragment(new TaskObjectiveUseItemQueryBuilder().WithAllScalarFields()
-					.WithZones(new TaskZoneQueryBuilder().WithMap(new MapQueryBuilder().WithId()).WithPosition(new MapPositionQueryBuilder().WithAllScalarFields()))
-					.WithUseAny(new ItemQueryBuilder().WithAllScalarFields())))
-			.WithTaskRequirements(new TaskStatusRequirementQueryBuilder().WithAllScalarFields()
-				.WithTask(new TaskQueryBuilder().WithAllScalarFields()))
-		, alias: "data", lang: language, gameMode: gameMode, limit: limit, offset: offset).Build();
+	private static string TasksQuery() => TasksQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
+	private static string TasksQuery(LanguageCode language, GameMode gameMode) {
+		string lang = ToGraphQlEnum(language);
+		string mode = ToGraphQlEnum(gameMode);
+		return $@"query {{
+  data: tasks(lang: {lang}, gameMode: {mode}) {{
+    id
+    name
+    taskImageLink
+    wikiLink
+    kappaRequired
+    trader {{
+      name
+      imageLink
+    }}
+    objectives {{
+      __typename
+      id
+      type
+      description
+      ... on TaskObjectiveItem {{
+        count
+        foundInRaid
+        items {{ id }}
+        zones {{
+          map {{ id }}
+          position {{ x y z }}
+        }}
+      }}
+      ... on TaskObjectiveMark {{
+        markerItem {{ id }}
+        zones {{
+          map {{ id }}
+          position {{ x y z }}
+        }}
+      }}
+      ... on TaskObjectiveBuildItem {{
+        item {{ id }}
+      }}
+      ... on TaskObjectiveBasic {{
+        zones {{
+          map {{ id }}
+          position {{ x y z }}
+        }}
+      }}
+      ... on TaskObjectiveQuestItem {{
+        zones {{
+          map {{ id }}
+          position {{ x y z }}
+        }}
+      }}
+      ... on TaskObjectiveUseItem {{
+        zones {{
+          map {{ id }}
+          position {{ x y z }}
+        }}
+      }}
+    }}
+  }}
+}}";
 	}
 
 	#endregion
@@ -349,20 +459,22 @@ public static class TarkovDevAPI {
 	private static string HideoutStationsQueryKey() => HideoutStationsQueryKey(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string HideoutStationsQueryKey(LanguageCode language, GameMode gameMode) => $"hideout_{language}_{gameMode}";
 
-	private static string HideoutStationsQueryPaginated(int limit, int offset) => HideoutStationsQueryPaginated(limit, offset, RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
-	private static string HideoutStationsQueryPaginated(int limit, int offset, LanguageCode language, GameMode gameMode) {
-		return new QueryQueryBuilder().WithHideoutStations(new HideoutStationQueryBuilder().WithAllScalarFields()
-			.WithLevels(new HideoutStationLevelQueryBuilder().WithAllScalarFields()
-				.WithItemRequirements(new RequirementItemQueryBuilder().WithAllScalarFields()
-					.WithItem(new ItemQueryBuilder().WithAllScalarFields()))
-				.WithStationLevelRequirements(new RequirementHideoutStationLevelQueryBuilder().WithAllScalarFields()
-					.WithStation(new HideoutStationQueryBuilder().WithAllScalarFields()))
-				.WithCrafts(new CraftQueryBuilder().WithAllScalarFields()
-					.WithRequiredItems(new ContainedItemQueryBuilder().WithAllScalarFields()
-						.WithItem(new ItemQueryBuilder().WithAllScalarFields()))
-					.WithRewardItems(new ContainedItemQueryBuilder().WithAllScalarFields()
-						.WithItem(new ItemQueryBuilder().WithAllScalarFields()))))
-		, alias: "data", lang: language, gameMode: gameMode, limit: limit, offset: offset).Build();
+	private static string HideoutStationsQuery() => HideoutStationsQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
+	private static string HideoutStationsQuery(LanguageCode language, GameMode gameMode) {
+		string lang = ToGraphQlEnum(language);
+		string mode = ToGraphQlEnum(gameMode);
+		return $@"query {{
+  data: hideoutStations(lang: {lang}, gameMode: {mode}) {{
+    levels {{
+      id
+      itemRequirements {{
+        id
+        count
+        item {{ id }}
+      }}
+    }}
+  }}
+}}";
 	}
 
 	#endregion
@@ -372,18 +484,20 @@ public static class TarkovDevAPI {
 	private static string MapsQueryKey() => MapsQueryKey(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string MapsQueryKey(LanguageCode language, GameMode gameMode) => $"maps_{language}_{gameMode}";
 
-	private static string MapsQueryPaginated(int limit, int offset) => MapsQueryPaginated(limit, offset, RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
-	private static string MapsQueryPaginated(int limit, int offset, LanguageCode language, GameMode gameMode)
-	{
-		return new QueryQueryBuilder().WithMaps(new MapQueryBuilder().WithAllScalarFields()
-			.WithExtracts(new MapExtractQueryBuilder().WithAllScalarFields()
-				.WithPosition(new MapPositionQueryBuilder().WithAllScalarFields())
-				.WithTransferItem(new ContainedItemQueryBuilder().WithAllScalarFields()
-					.WithItem(new ItemQueryBuilder().WithId())))
-			.WithTransits(new MapTransitQueryBuilder().WithAllScalarFields()
-				.WithPosition(new MapPositionQueryBuilder().WithAllScalarFields()))
-		, alias: "data", lang: language, gameMode: gameMode, limit: limit, offset: offset).Build();
+	private static string MapsQuery() => MapsQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
+	private static string MapsQuery(LanguageCode language, GameMode gameMode) {
+		string lang = ToGraphQlEnum(language);
+		string mode = ToGraphQlEnum(gameMode);
+		return $@"query {{
+  data: maps(lang: {lang}, gameMode: {mode}) {{
+    id
+    name
+    normalizedName
+  }}
+}}";
 	}
 
 	#endregion
+
+	private static string ToGraphQlEnum(Enum value) => value.ToString().ToLowerInvariant();
 }

--- a/RatScanner/TarkovDevAPI.cs
+++ b/RatScanner/TarkovDevAPI.cs
@@ -1,11 +1,10 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using RatScanner.TarkovDev.GraphQL;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -18,23 +17,44 @@ namespace RatScanner;
 public static class TarkovDevAPI {
 	private class ResponseData<T> {
 		[JsonProperty("data")]
-		public ResponseDataInner<T> Data { get; set; }
+		public ResponseDataInner<T>? Data { get; set; }
 	}
 
 	private class ResponseDataInner<T> {
 		[JsonProperty("data")]
-		public T Data { get; set; }
+		public T? Data { get; set; }
+	}
+
+	private sealed class RateLimitedException : Exception {
+		public TimeSpan? RetryAfter { get; }
+
+		public RateLimitedException(TimeSpan? retryAfter, string message) : base(message) {
+			RetryAfter = retryAfter;
+		}
 	}
 
 	const string ApiEndpoint = "https://api.tarkov.dev/graphql";
-	const int BatchSize = 1000;
 
 	private static readonly ConcurrentDictionary<string, (long expire, object response)> Cache = new();
-	private static readonly ConcurrentDictionary<string, bool> PendingRequests = new();
+	private static readonly ConcurrentDictionary<string, Lazy<Task>> InFlightRequests = new();
+	private static readonly ConcurrentDictionary<string, long> BackoffUntil = new();
 
-	private static readonly HttpClient HttpClient = new(new HttpClientHandler {
-		AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate,
-	});
+	private static readonly HttpClient HttpClient = CreateHttpClient();
+
+	private static HttpClient CreateHttpClient() {
+		HttpClient client = new(new HttpClientHandler {
+			AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli,
+		});
+		client.Timeout = TimeSpan.FromSeconds(30);
+		// Some upstreams reject requests without a user-agent.
+		try {
+			client.DefaultRequestHeaders.UserAgent.ParseAdd($"RatScanner/{RatConfig.Version}");
+		} catch (Exception e) {
+			Logger.LogWarning("Failed to set user-agent header; falling back to default RatScanner user-agent.", e);
+			client.DefaultRequestHeaders.UserAgent.ParseAdd("RatScanner");
+		}
+		return client;
+	}
 
 	private static readonly JsonSerializerSettings JsonSettings = new() {
 		MissingMemberHandling = MissingMemberHandling.Ignore,
@@ -43,12 +63,33 @@ public static class TarkovDevAPI {
 		TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
 	};
 
-	private static async Task<Stream> Get(string query) {
+	private static async Task<string> GetResponseString(string query) {
 		Dictionary<string, string> body = new() { { "query", query } };
-		HttpResponseMessage responseTask = await HttpClient.PostAsJsonAsync(ApiEndpoint, body);
+		using HttpResponseMessage response = await HttpClient.PostAsJsonAsync(ApiEndpoint, body).ConfigureAwait(false);
 
-		if (responseTask.StatusCode != HttpStatusCode.OK) throw new Exception($"Tarkov.dev API request failed. {responseTask.ReasonPhrase}");
-		return await responseTask.Content.ReadAsStreamAsync();
+		string responseBody = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+		if (response.StatusCode == HttpStatusCode.TooManyRequests) {
+			string trimmed = responseBody;
+			if (trimmed.Length > 512) trimmed = trimmed.Substring(0, 512) + "...";
+			throw new RateLimitedException(GetRetryAfter(response), $"Tarkov.dev API rate limited (429). Body: {trimmed}");
+		}
+		if (response.StatusCode != HttpStatusCode.OK) {
+			string trimmed = responseBody;
+			if (trimmed.Length > 512) trimmed = trimmed.Substring(0, 512) + "...";
+			throw new Exception($"Tarkov.dev API request failed ({(int)response.StatusCode} {response.ReasonPhrase}). Body: {trimmed}");
+		}
+		return responseBody;
+	}
+
+	private static TimeSpan? GetRetryAfter(HttpResponseMessage response) {
+		if (response.Headers.RetryAfter?.Delta != null) {
+			return response.Headers.RetryAfter.Delta;
+		}
+		if (response.Headers.RetryAfter?.Date != null) {
+			TimeSpan delta = response.Headers.RetryAfter.Date.Value - DateTimeOffset.UtcNow;
+			return delta < TimeSpan.Zero ? TimeSpan.Zero : delta;
+		}
+		return null;
 	}
 
 	/// <summary>
@@ -58,13 +99,19 @@ public static class TarkovDevAPI {
 	private static bool TryLoadFromOfflineCache<T>(string baseQueryKey, long ttl) where T : class {
 		if (Cache.ContainsKey(baseQueryKey)) return true;
 
-		if (RatConfig.ReadFromCache(baseQueryKey, out string cachedResponse)) {
+		if (RatConfig.ReadFromCache(baseQueryKey, out string cachedResponse, out DateTimeOffset lastWriteUtc)) {
 			try {
 				ResponseData<T[]>? neededResponse = JsonConvert.DeserializeObject<ResponseData<T[]>?>(cachedResponse, JsonSettings);
 				if (neededResponse?.Data?.Data != null) {
 					long time = DateTimeOffset.Now.ToUnixTimeSeconds();
-					// Use expired TTL so background refresh will be triggered
-					Cache[baseQueryKey] = (time - 1, neededResponse.Data.Data);
+					long expire = time - 1;
+					if (ttl > 0 && lastWriteUtc != DateTimeOffset.MinValue) {
+						long ageSeconds = Math.Max(0, (long)(DateTimeOffset.UtcNow - lastWriteUtc).TotalSeconds);
+						if (ageSeconds < ttl) {
+							expire = time + (ttl - ageSeconds);
+						}
+					}
+					Cache[baseQueryKey] = (expire, neededResponse.Data.Data);
 					Logger.LogInfo($"Loaded {neededResponse.Data.Data.Length} items from offline cache for: \"{baseQueryKey}\"");
 					return true;
 				}
@@ -76,66 +123,48 @@ public static class TarkovDevAPI {
 	}
 
 	/// <summary>
-	/// Fetches paginated data in batches and combines results
+	/// Fetches all data in a single request
 	/// </summary>
-	private static async Task QueuePaginatedRequest<T>(string baseQueryKey, Func<int, int, string> queryBuilder, long ttl) where T : class {
-		// Check if request is already pending
-		if (!PendingRequests.TryAdd(baseQueryKey, true)) {
-			Logger.LogInfo($"Request already pending for: \"{baseQueryKey}\", skipping");
-			return;
-		}
-
+	private static async Task QueueRequestInternal<T>(string baseQueryKey, Func<string> queryBuilder, long ttl) where T : class {
 		try {
-			List<T> allResults = new();
-			List<string> rawBatchResponses = new();
-			int offset = 0;
-			bool hasMore = true;
-
 			Stopwatch sw = Stopwatch.StartNew();
+			string query = queryBuilder();
+			Logger.LogInfo($"Fetching data for: \"{baseQueryKey}\"");
 
-			while (hasMore) {
-				string query = queryBuilder(BatchSize, offset);
-				Logger.LogInfo($"Fetching batch at offset {offset} for: \"{baseQueryKey}\"");
+			// Read raw response for caching
+			string rawResponse = await GetResponseString(query).ConfigureAwait(false);
 
-				using Stream stream = await Get(query);
-				using StreamReader streamReader = new(stream);
-				
-				// Read raw response for caching
-				string rawResponse = await streamReader.ReadToEndAsync();
-				rawBatchResponses.Add(rawResponse);
-				
-				// Parse the response
-				ResponseData<T[]>? neededResponse = JsonConvert.DeserializeObject<ResponseData<T[]>>(rawResponse, JsonSettings);
-				if (neededResponse?.Data?.Data == null) throw new Exception("Failed to deserialize paginated response");
+			// Parse the response
+			ResponseData<T[]>? neededResponse = JsonConvert.DeserializeObject<ResponseData<T[]>>(rawResponse, JsonSettings);
+			if (neededResponse?.Data?.Data == null) throw new Exception("Failed to deserialize response");
 
-				T[] batchResults = neededResponse.Data.Data;
-				allResults.AddRange(batchResults);
+			T[] results = neededResponse.Data.Data;
 
-				Logger.LogInfo($"Fetched {batchResults.Length} items at offset {offset} for: \"{baseQueryKey}\"");
-
-				// If we got less than BatchSize, we've reached the end
-				hasMore = batchResults.Length >= BatchSize;
-				offset += BatchSize;
-			}
-
-			// Store combined results in cache
+			// Store results in cache
 			long time = DateTimeOffset.Now.ToUnixTimeSeconds();
-			T[] finalResults = allResults.ToArray();
-			Cache[baseQueryKey] = (time + ttl, finalResults);
+			Cache[baseQueryKey] = (time + ttl, results);
+			BackoffUntil.TryRemove(baseQueryKey, out _);
 
-			// Combine raw responses for cache - extract and merge the data arrays
-			string combinedCacheJson = CombineRawResponses<T>(rawBatchResponses);
-			RatConfig.WriteToCache(baseQueryKey, combinedCacheJson);
+			// Cache raw response for offline use
+			RatConfig.WriteToCache(baseQueryKey, rawResponse);
 
-			Logger.LogInfo($"Completed paginated fetch in {sw.ElapsedMilliseconds}ms: {allResults.Count} total items for \"{baseQueryKey}\"");
+			Logger.LogInfo($"Completed fetch in {sw.ElapsedMilliseconds}ms: {results.Length} total items for \"{baseQueryKey}\"");
 		} catch (Exception e) {
-			Logger.LogWarning($"Failed paginated request for: \"{baseQueryKey}\".", e);
+			Logger.LogWarning($"Failed request for: \"{baseQueryKey}\".", e);
+
+			if (e is RateLimitedException rateLimited) {
+				ApplyBackoff(baseQueryKey, rateLimited.RetryAfter);
+			}
 
 			// If we have existing cached data, extend its TTL to prevent rapid retries
 			if (Cache.TryGetValue(baseQueryKey, out var existingCache))
 			{
 				long time = DateTimeOffset.Now.ToUnixTimeSeconds();
-				Cache[baseQueryKey] = (time + RatConfig.SuperShortTTL, existingCache.response);
+				long expire = time + RatConfig.SuperShortTTL;
+				if (BackoffUntil.TryGetValue(baseQueryKey, out long until)) {
+					expire = Math.Max(expire, until);
+				}
+				Cache[baseQueryKey] = (expire, existingCache.response);
 				Logger.LogInfo($"Extended cache TTL for: \"{baseQueryKey}\" to prevent rapid retries");
 				return;
 			}
@@ -147,58 +176,92 @@ public static class TarkovDevAPI {
 				ResponseData<T[]>? neededResponse = JsonConvert.DeserializeObject<ResponseData<T[]>?>(cachedResponse, JsonSettings);
 				if (neededResponse?.Data?.Data != null) {
 					long time = DateTimeOffset.Now.ToUnixTimeSeconds();
-					Cache[baseQueryKey] = (time + RatConfig.SuperShortTTL, neededResponse.Data.Data);
+					long expire = time + RatConfig.SuperShortTTL;
+					if (BackoffUntil.TryGetValue(baseQueryKey, out long until)) {
+						expire = Math.Max(expire, until);
+					}
+					Cache[baseQueryKey] = (expire, neededResponse.Data.Data);
 					return;
 				}
 			}
 
-			if (!Cache.ContainsKey(baseQueryKey)) throw new Exception("Failed to fetch paginated query response and no cache available.");
-		} finally {
-			// Always remove from pending requests when done
-			PendingRequests.TryRemove(baseQueryKey, out _);
+			if (!Cache.ContainsKey(baseQueryKey)) {
+				throw new Exception("Failed to fetch query response and no cache available.");
+			}
 		}
 	}
 
-	/// <summary>
-	/// Combines multiple raw JSON responses into a single cached response, preserving __typename fields
-	/// </summary>
-	private static string CombineRawResponses<T>(List<string> rawResponses) where T : class {
-		List<Newtonsoft.Json.Linq.JToken> allDataItems = new();
-
-		foreach (string rawResponse in rawResponses) {
-			var json = Newtonsoft.Json.Linq.JObject.Parse(rawResponse);
-			var dataArray = json["data"]?["data"] as Newtonsoft.Json.Linq.JArray;
-			if (dataArray != null) {
-				allDataItems.AddRange(dataArray);
-			}
+	private static Task QueueRequest<T>(string baseQueryKey, Func<string> queryBuilder, long ttl) where T : class {
+		if (InFlightRequests.TryGetValue(baseQueryKey, out Lazy<Task> existingLazy)) {
+			return existingLazy.Value;
+		}
+		if (IsInBackoff(baseQueryKey)) {
+			return Task.CompletedTask;
 		}
 
-		// Create combined response structure
-		var combined = new Newtonsoft.Json.Linq.JObject {
-			["data"] = new Newtonsoft.Json.Linq.JObject {
-				["data"] = new Newtonsoft.Json.Linq.JArray(allDataItems)
-			}
-		};
-
-		return combined.ToString(Newtonsoft.Json.Formatting.None);
+		Lazy<Task> newLazy = new(() => QueueRequestInternal<T>(baseQueryKey, queryBuilder, ttl));
+		Lazy<Task> lazy = InFlightRequests.GetOrAdd(baseQueryKey, newLazy);
+		Task task = lazy.Value;
+		if (lazy == newLazy) {
+			_ = task.ContinueWith(_ => InFlightRequests.TryRemove(baseQueryKey, out Lazy<Task> _), TaskScheduler.Default);
+		}
+		return task;
 	}
 
-	private static T[] GetCachedPaginated<T>(string baseQueryKey, Func<int, int, string> queryBuilder, long ttl, bool isRetry = false) where T : class {
-		if (!Cache.TryGetValue(baseQueryKey, out (long expire, object response) value)) {
-			if (isRetry) throw new Exception("Retrying to fetch paginated query response failed.");
+	private static T[] GetCached<T>(string baseQueryKey, Func<string> queryBuilder, long ttl) where T : class {
+		try {
+			if (!Cache.TryGetValue(baseQueryKey, out (long expire, object response) value)) {
+				if (IsInBackoff(baseQueryKey)) {
+					return Array.Empty<T>();
+				}
+				if (InFlightRequests.ContainsKey(baseQueryKey)) {
+					return Array.Empty<T>();
+				}
 
-			Logger.LogInfo($"Paginated query not found in cache: \"{baseQueryKey}\"");
-			Task.Run(() => QueuePaginatedRequest<T>(baseQueryKey, queryBuilder, ttl)).Wait();
-			return GetCachedPaginated<T>(baseQueryKey, queryBuilder, ttl, true);
+				Logger.LogInfo($"Cache miss for: \"{baseQueryKey}\", queuing fetch.");
+				try {
+					_ = QueueRequest<T>(baseQueryKey, queryBuilder, ttl);
+				} catch (Exception e) {
+					Logger.LogWarning($"Failed to queue request for: \"{baseQueryKey}\", returning empty.", e);
+				}
+				return Array.Empty<T>();
+			}
+
+			// Queue request if cache is expired and no request is already pending
+			long time = DateTimeOffset.Now.ToUnixTimeSeconds();
+			if (time > value.expire && !IsInBackoff(baseQueryKey) && !InFlightRequests.ContainsKey(baseQueryKey)) {
+				_ = QueueRequest<T>(baseQueryKey, queryBuilder, ttl);
+			}
+
+			return (T[])value.response;
+		} catch (Exception e) {
+			Logger.LogWarning($"Failed to get cached data for: \"{baseQueryKey}\", returning empty.", e);
+			return Array.Empty<T>();
 		}
+	}
 
-		// Queue request if cache is expired and no request is already pending
+	private static bool IsInBackoff(string baseQueryKey) {
 		long time = DateTimeOffset.Now.ToUnixTimeSeconds();
-		if (time > value.expire && !PendingRequests.ContainsKey(baseQueryKey)) {
-			Task.Run(() => QueuePaginatedRequest<T>(baseQueryKey, queryBuilder, ttl));
+		if (BackoffUntil.TryGetValue(baseQueryKey, out long until)) {
+			if (until > time) {
+				return true;
+			}
+			BackoffUntil.TryRemove(baseQueryKey, out _);
 		}
+		return false;
+	}
 
-		return (T[])value.response;
+	private static void ApplyBackoff(string baseQueryKey, TimeSpan? retryAfter) {
+		double delaySeconds = retryAfter?.TotalSeconds ?? RatConfig.SuperShortTTL;
+		long backoffSeconds = (long)Math.Ceiling(Math.Max(delaySeconds, RatConfig.SuperShortTTL));
+		long time = DateTimeOffset.Now.ToUnixTimeSeconds();
+		long until = time + backoffSeconds;
+		BackoffUntil[baseQueryKey] = until;
+
+		if (Cache.TryGetValue(baseQueryKey, out var existingCache)) {
+			Cache[baseQueryKey] = (Math.Max(existingCache.expire, until), existingCache.response);
+		}
+		Logger.LogInfo($"Rate limited for: \"{baseQueryKey}\". Backing off for {backoffSeconds}s.");
 	}
 
 	/// <summary>
@@ -207,14 +270,14 @@ public static class TarkovDevAPI {
 	/// </summary>
 	public static bool TryInitializeCacheFromOffline() {
 		Logger.LogInfo("Attempting to load API cache from offline storage...");
-		
+
 		bool itemsLoaded = TryLoadFromOfflineCache<Item>(ItemsQueryKey(), RatConfig.MediumTTL);
 		bool tasksLoaded = TryLoadFromOfflineCache<TTask>(TasksQueryKey(), RatConfig.LongTTL);
 		bool hideoutLoaded = TryLoadFromOfflineCache<HideoutStation>(HideoutStationsQueryKey(), RatConfig.LongTTL);
 		bool mapsLoaded = TryLoadFromOfflineCache<Map>(MapsQueryKey(), RatConfig.LongTTL);
 
 		bool allLoaded = itemsLoaded && tasksLoaded && hideoutLoaded && mapsLoaded;
-		
+
 		if (allLoaded) {
 			Logger.LogInfo("All API caches loaded from offline storage");
 		} else {
@@ -224,37 +287,60 @@ public static class TarkovDevAPI {
 		return allLoaded;
 	}
 
+	internal static bool AnyCacheExpired() {
+		long time = DateTimeOffset.Now.ToUnixTimeSeconds();
+		return IsCacheExpired(ItemsQueryKey(), time)
+			|| IsCacheExpired(TasksQueryKey(), time)
+			|| IsCacheExpired(HideoutStationsQueryKey(), time)
+			|| IsCacheExpired(MapsQueryKey(), time);
+	}
+
+	private static bool IsCacheExpired(string baseQueryKey, long time) {
+		if (!Cache.TryGetValue(baseQueryKey, out (long expire, object response) cached)) {
+			return true;
+		}
+		return time > cached.expire;
+	}
+
 	/// <summary>
 	/// Full cache initialization - waits for all requests to complete
 	/// </summary>
 	public static async Task InitializeCache() {
 		await Task.WhenAll(
-			Task.Run(() => QueuePaginatedRequest<Item>(ItemsQueryKey(), ItemsQueryPaginated, RatConfig.MediumTTL)),
-			Task.Run(() => QueuePaginatedRequest<TTask>(TasksQueryKey(), TasksQueryPaginated, RatConfig.LongTTL)),
-			Task.Run(() => QueuePaginatedRequest<HideoutStation>(HideoutStationsQueryKey(), HideoutStationsQueryPaginated, RatConfig.LongTTL)),
-			Task.Run(() => QueuePaginatedRequest<Map>(MapsQueryKey(), MapsQueryPaginated, RatConfig.LongTTL))
+			QueueRequest<Item>(ItemsQueryKey(), ItemsQuery, RatConfig.MediumTTL),
+			QueueRequest<TTask>(TasksQueryKey(), TasksQuery, RatConfig.LongTTL),
+			QueueRequest<HideoutStation>(HideoutStationsQueryKey(), HideoutStationsQuery, RatConfig.LongTTL),
+			QueueRequest<Map>(MapsQueryKey(), MapsQuery, RatConfig.LongTTL)
 		).ConfigureAwait(false);
 	}
 
-	public static Item[] GetItems(LanguageCode language, GameMode gameMode) => GetCachedPaginated<Item>(ItemsQueryKey(language, gameMode), (limit, offset) => ItemsQueryPaginated(limit, offset, language, gameMode), RatConfig.MediumTTL);
-	public static Item[] GetItems() => GetCachedPaginated<Item>(ItemsQueryKey(), ItemsQueryPaginated, RatConfig.MediumTTL);
+	public static Item[] GetItems(LanguageCode language, GameMode gameMode) => GetCached<Item>(ItemsQueryKey(language, gameMode), () => ItemsQuery(language, gameMode), RatConfig.MediumTTL);
+	public static Item[] GetItems() => GetCached<Item>(ItemsQueryKey(), ItemsQuery, RatConfig.MediumTTL);
+	public static bool TryGetCachedItems(out Item[] items) {
+		if (Cache.TryGetValue(ItemsQueryKey(), out (long expire, object response) cached)) {
+			items = (Item[])cached.response;
+			return true;
+		}
+		items = Array.Empty<Item>();
+		return false;
+	}
 
-	public static TTask[] GetTasks(LanguageCode language, GameMode gameMode) => GetCachedPaginated<TTask>(TasksQueryKey(language, gameMode), (limit, offset) => TasksQueryPaginated(limit, offset, language, gameMode), RatConfig.LongTTL);
-	public static TTask[] GetTasks() => GetCachedPaginated<TTask>(TasksQueryKey(), TasksQueryPaginated, RatConfig.LongTTL);
+	public static TTask[] GetTasks(LanguageCode language, GameMode gameMode) => GetCached<TTask>(TasksQueryKey(language, gameMode), () => TasksQuery(language, gameMode), RatConfig.LongTTL);
+	public static TTask[] GetTasks() => GetCached<TTask>(TasksQueryKey(), TasksQuery, RatConfig.LongTTL);
 
-	public static HideoutStation[] GetHideoutStations(LanguageCode language, GameMode gameMode) => GetCachedPaginated<HideoutStation>(HideoutStationsQueryKey(language, gameMode), (limit, offset) => HideoutStationsQueryPaginated(limit, offset, language, gameMode), RatConfig.LongTTL);
-	public static HideoutStation[] GetHideoutStations() => GetCachedPaginated<HideoutStation>(HideoutStationsQueryKey(), HideoutStationsQueryPaginated, RatConfig.LongTTL);
+	public static HideoutStation[] GetHideoutStations(LanguageCode language, GameMode gameMode) => GetCached<HideoutStation>(HideoutStationsQueryKey(language, gameMode), () => HideoutStationsQuery(language, gameMode), RatConfig.LongTTL);
+	public static HideoutStation[] GetHideoutStations() => GetCached<HideoutStation>(HideoutStationsQueryKey(), HideoutStationsQuery, RatConfig.LongTTL);
 
-	public static Map[] GetMaps(LanguageCode language, GameMode gameMode) => GetCachedPaginated<Map>(MapsQueryKey(language, gameMode), (limit, offset) => MapsQueryPaginated(limit, offset, language, gameMode), RatConfig.LongTTL);
-	public static Map[] GetMaps() => GetCachedPaginated<Map>(MapsQueryKey(), MapsQueryPaginated, RatConfig.LongTTL);
+	public static Map[] GetMaps(LanguageCode language, GameMode gameMode) => GetCached<Map>(MapsQueryKey(language, gameMode), () => MapsQuery(language, gameMode), RatConfig.LongTTL);
+	public static Map[] GetMaps() => GetCached<Map>(MapsQueryKey(), MapsQuery, RatConfig.LongTTL);
 
 	#region Items Query
 
 	private static string ItemsQueryKey() => ItemsQueryKey(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string ItemsQueryKey(LanguageCode language, GameMode gameMode) => $"items_{language}_{gameMode}";
 
-	private static string ItemsQueryPaginated(int limit, int offset) => ItemsQueryPaginated(limit, offset, RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
-	private static string ItemsQueryPaginated(int limit, int offset, LanguageCode language, GameMode gameMode) {
+	private static string ItemsQuery() => ItemsQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
+	private static string ItemsQuery(LanguageCode language, GameMode gameMode) {
 		return new QueryQueryBuilder().WithItems(new ItemQueryBuilder().WithAllScalarFields()
 		.WithProperties(new ItemPropertiesQueryBuilder().WithAllScalarFields()
 			.WithItemPropertiesAmmoFragment(new ItemPropertiesAmmoQueryBuilder().WithAllScalarFields())
@@ -281,7 +367,7 @@ public static class TarkovDevAPI {
 		.WithCraftsFor(new CraftQueryBuilder().WithId())
 		.WithCraftsUsing(new CraftQueryBuilder().WithId())
 		.WithTypes()
-		, alias: "data", lang: language, gameMode: gameMode, limit: limit, offset: offset).Build();
+		, alias: "data", lang: language, gameMode: gameMode).Build();
 	}
 
 	#endregion
@@ -291,8 +377,8 @@ public static class TarkovDevAPI {
 	private static string TasksQueryKey() => TasksQueryKey(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string TasksQueryKey(LanguageCode language, GameMode gameMode) => $"tasks_{language}_{gameMode}";
 
-	private static string TasksQueryPaginated(int limit, int offset) => TasksQueryPaginated(limit, offset, RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
-	private static string TasksQueryPaginated(int limit, int offset, LanguageCode language, GameMode gameMode) {
+	private static string TasksQuery() => TasksQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
+	private static string TasksQuery(LanguageCode language, GameMode gameMode) {
 		return new QueryQueryBuilder().WithTasks(new TaskQueryBuilder().WithAllScalarFields()
 			.WithKappaRequired()
 			.WithMap(new MapQueryBuilder().WithId())
@@ -339,7 +425,7 @@ public static class TarkovDevAPI {
 					.WithUseAny(new ItemQueryBuilder().WithId())))
 			.WithTaskRequirements(new TaskStatusRequirementQueryBuilder().WithAllScalarFields()
 				.WithTask(new TaskQueryBuilder().WithId()))
-		, alias: "data", lang: language, gameMode: gameMode, limit: limit, offset: offset).Build();
+		, alias: "data", lang: language, gameMode: gameMode).Build();
 	}
 
 	#endregion
@@ -349,8 +435,8 @@ public static class TarkovDevAPI {
 	private static string HideoutStationsQueryKey() => HideoutStationsQueryKey(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string HideoutStationsQueryKey(LanguageCode language, GameMode gameMode) => $"hideout_{language}_{gameMode}";
 
-	private static string HideoutStationsQueryPaginated(int limit, int offset) => HideoutStationsQueryPaginated(limit, offset, RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
-	private static string HideoutStationsQueryPaginated(int limit, int offset, LanguageCode language, GameMode gameMode) {
+	private static string HideoutStationsQuery() => HideoutStationsQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
+	private static string HideoutStationsQuery(LanguageCode language, GameMode gameMode) {
 		return new QueryQueryBuilder().WithHideoutStations(new HideoutStationQueryBuilder().WithAllScalarFields()
 			.WithLevels(new HideoutStationLevelQueryBuilder().WithAllScalarFields()
 				.WithItemRequirements(new RequirementItemQueryBuilder().WithAllScalarFields()
@@ -362,7 +448,7 @@ public static class TarkovDevAPI {
 						.WithItem(new ItemQueryBuilder().WithId()))
 					.WithRewardItems(new ContainedItemQueryBuilder().WithAllScalarFields()
 						.WithItem(new ItemQueryBuilder().WithId()))))
-		, alias: "data", lang: language, gameMode: gameMode, limit: limit, offset: offset).Build();
+		, alias: "data", lang: language, gameMode: gameMode).Build();
 	}
 
 	#endregion
@@ -372,9 +458,8 @@ public static class TarkovDevAPI {
 	private static string MapsQueryKey() => MapsQueryKey(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
 	private static string MapsQueryKey(LanguageCode language, GameMode gameMode) => $"maps_{language}_{gameMode}";
 
-	private static string MapsQueryPaginated(int limit, int offset) => MapsQueryPaginated(limit, offset, RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
-	private static string MapsQueryPaginated(int limit, int offset, LanguageCode language, GameMode gameMode)
-	{
+	private static string MapsQuery() => MapsQuery(RatConfig.NameScan.Language.ToTarkovDevType(), RatConfig.GameMode);
+	private static string MapsQuery(LanguageCode language, GameMode gameMode) {
 		return new QueryQueryBuilder().WithMaps(new MapQueryBuilder().WithAllScalarFields()
 			.WithExtracts(new MapExtractQueryBuilder().WithAllScalarFields()
 				.WithPosition(new MapPositionQueryBuilder().WithAllScalarFields())
@@ -382,7 +467,7 @@ public static class TarkovDevAPI {
 					.WithItem(new ItemQueryBuilder().WithId())))
 			.WithTransits(new MapTransitQueryBuilder().WithAllScalarFields()
 				.WithPosition(new MapPositionQueryBuilder().WithAllScalarFields()))
-		, alias: "data", lang: language, gameMode: gameMode, limit: limit, offset: offset).Build();
+		, alias: "data", lang: language, gameMode: gameMode).Build();
 	}
 
 	#endregion


### PR DESCRIPTION
This commit addresses API rate limiting issues with tarkov.dev and improves overall application startup behavior.

# Core issue fixed is Pagination reports

## API Changes (TarkovDevAPI.cs)
- Remove pagination logic in favor of single requests with trimmed queries
- Add proper rate limiting detection with HTTP 429 handling
- Implement exponential backoff when rate limited (respects Retry-After header)
- Add request deduplication to prevent concurrent duplicate API calls
- Add Brotli compression support for responses
- Include User-Agent header to comply with API requirements
- Simplify GraphQL queries to fetch only required fields

## Cache Improvements (TarkovDevAPI.cs, RatConfig.cs)
- Calculate cache freshness based on file modification time
- Skip unnecessary background refresh when cache is still valid
- Add TryGetCachedItems() for safe non-blocking cache access
- Add AnyCacheExpired() to check if refresh is needed
- Refactor cache path logic into GetCachePath() helper

## Startup Improvements (RatScannerMain.cs)
- Remove blocking .Wait() call on API initialization
- Show placeholder item while cache loads asynchronously
- Reinitialize RatEye once items become available
- Handle graceful degradation when cache is not ready

## Update Check Fix (RatScannerMain.cs)
- Fix version comparison to use semantic versioning
- Prevent false update prompts when running newer/dev versions
- Handle version strings with prefixes (v) and suffixes (-beta, +build)

## Other Fixes
- Fix null reference warning in MapDataLoader when map not found
- Fix potential null reference in timer callback
- Add nullable annotation to OnPropertyChanged parameter
- Bump version to 3.9.3

Fixes #777
Fixes #782
Fixes #781
Fixes #771
Fixes #773
Fixes #769
Fixes #767
Fixes #766
(Likely More)