### PR TITLE
New Feature: Show Current Item Progress 

### DIFF
--- a/RatScanner/ItemExtensions.cs
+++ b/RatScanner/ItemExtensions.cs
@@ -15,7 +15,7 @@ public partial class Item {
 		return progress ?? new UserProgress();
 	}
 
-	public (int count, int kappaCount) GetTaskRemaining(UserProgress? progress = null) {
+	public (int count, int kappaCount, int total, int kappaTotal) GetTaskRemaining(UserProgress? progress = null) {
 		// Compensation for Damage Tasks
 		// These tasks are not tracked by TarkovTracker
 		string[] excludedTasks = new string[] {
@@ -31,6 +31,8 @@ public partial class Item {
 		int needed = 0;
 		int count = 0;
 		int kappaCount = 0;
+		int total = 0;
+		int kappaTotal = 0;
 
 		bool showNonFir = RatConfig.Tracking.ShowNonFIRNeeds;
 
@@ -51,7 +53,8 @@ public partial class Item {
 					if (!objective.Items.Contains(Id)) continue;	// Skip if item is not the one we are looking for
 					if (!showNonFir && !objective.FoundInRaid) continue;					// Skip if item is not FIR
 					needed = objective.Count;
-					if (task.KappaRequired == true) kappaCount += objective.Count;
+					total += objective.Count;
+					if (task.KappaRequired == true) kappaTotal += objective.Count;
 					// Subtract amount of already collected items
 					List<Progress> objectiveProgress = progress.TaskObjectives.Where(p => p.Id == objective.Id).ToList();
 					foreach (Progress p in objectiveProgress) needed -= p.Complete ? objective.Count : p.Count;
@@ -61,6 +64,8 @@ public partial class Item {
 					if (!objective.Items.Contains(Id)) continue;	// Skip if item is not the one we are looking for
 					if (!showNonFir) continue;										// Skip if item is not FIR
 					needed = objective.Count;
+					total += objective.Count;
+					if (task.KappaRequired == true) kappaTotal += objective.Count;
 					List<Progress> objectiveProgress = progress.TaskObjectives.Where(p => p.Id == objective.Id).ToList();
 					foreach (Progress p in objectiveProgress) needed -= p.Complete ? objective.Count : p.Count;
 					count += needed;
@@ -69,6 +74,8 @@ public partial class Item {
 					if (objective.MarkerItem != Id) continue;  // Skip if item is not the one we are looking for
 					if (!showNonFir) continue;                      // Skip if item is not FIR
 					needed = 1;
+					total += 1;
+					if (task.KappaRequired == true) kappaTotal += 1;
 					List<Progress> objectiveProgress = progress.TaskObjectives.Where(p => p.Id == objective.Id).ToList();
 					foreach (Progress p in objectiveProgress) needed -= 1;
 					count += needed;
@@ -77,6 +84,8 @@ public partial class Item {
 					if (objective.Item != Id) continue; // Skip if item is not the one we are looking for
 					if (!showNonFir) continue;                      // Skip if item is not FIR
 					needed = 1;
+					total += 1;
+					if (task.KappaRequired == true) kappaTotal += 1;
 					List<Progress> objectiveProgress = progress.TaskObjectives.Where(p => p.Id == objective.Id).ToList();
 					foreach (Progress p in objectiveProgress) needed -= 1;
 					count += needed;
@@ -84,15 +93,16 @@ public partial class Item {
 				}
 			}
 		}
-		return (count, kappaCount);
+		return (count, kappaCount, total, kappaTotal);
 	}
 
-	public int GetHideoutRemaining(UserProgress? progress = null) {
+	public (int count, int total) GetHideoutRemaining(UserProgress? progress = null) {
 		progress ??= GetUserProgress();
 		progress.Tasks ??= new List<Progress>();
 		progress.TaskObjectives ??= new List<Progress>();
 
 		int count = 0;
+		int total = 0;
 		HideoutStation[] stations = TarkovDevAPI.GetHideoutStations();
 
 		foreach (HideoutStation station in stations) {
@@ -108,12 +118,13 @@ public partial class Item {
 					if (requiredItem?.Item != Id) continue;
 
 					count += requiredItem.Count;
+					total += requiredItem.Count;
 					List<Progress> objectiveProgress = progress.HideoutParts.Where(p => p.Id == requiredItem.Id).ToList();
 					foreach (Progress p in objectiveProgress) count -= p.Complete ? requiredItem.Count : p.Count;
 				}
 			}
 		}
-		return count;
+		return (count, total);
 	}
 
 	public IEnumerable<Item> GetAmmoOfSameCaliber() {

--- a/RatScanner/ItemExtensions.cs
+++ b/RatScanner/ItemExtensions.cs
@@ -1,4 +1,4 @@
-using RatScanner.FetchModels.TarkovTracker;
+﻿using RatScanner.FetchModels.TarkovTracker;
 using RatScanner.TarkovDev.Json;
 using System.Collections.Generic;
 using System.Linq;
@@ -15,7 +15,7 @@ public partial class Item {
 		return progress ?? new UserProgress();
 	}
 
-	public (int count, int kappaCount, int total, int kappaTotal) GetTaskRemaining(UserProgress? progress = null) {
+	public (int count, int kappaCount, int total, int kappaTotal, int owned, int kappaOwned) GetTaskRemaining(UserProgress? progress = null) {
 		// Compensation for Damage Tasks
 		// These tasks are not tracked by TarkovTracker
 		string[] excludedTasks = new string[] {
@@ -33,6 +33,8 @@ public partial class Item {
 		int kappaCount = 0;
 		int total = 0;
 		int kappaTotal = 0;
+		int owned = 0;
+		int kappaOwned = 0;
 
 		bool showNonFir = RatConfig.Tracking.ShowNonFIRNeeds;
 
@@ -58,6 +60,10 @@ public partial class Item {
 					// Subtract amount of already collected items
 					List<Progress> objectiveProgress = progress.TaskObjectives.Where(p => p.Id == objective.Id).ToList();
 					foreach (Progress p in objectiveProgress) needed -= p.Complete ? objective.Count : p.Count;
+					// Items of completed objectives are already handed in, so they are not owned anymore
+					int objectiveOwned = objectiveProgress.Where(p => !p.Complete).Sum(p => p.Count);
+					owned += objectiveOwned;
+					if (task.KappaRequired == true) kappaOwned += objectiveOwned;
 					count += needed;
 					if (task.KappaRequired == true) kappaCount += needed;
 				} else if (objective.Type == "plantItem") {
@@ -68,6 +74,10 @@ public partial class Item {
 					if (task.KappaRequired == true) kappaTotal += objective.Count;
 					List<Progress> objectiveProgress = progress.TaskObjectives.Where(p => p.Id == objective.Id).ToList();
 					foreach (Progress p in objectiveProgress) needed -= p.Complete ? objective.Count : p.Count;
+					// Items of completed objectives are already planted, so they are not owned anymore
+					int objectiveOwned = objectiveProgress.Where(p => !p.Complete).Sum(p => p.Count);
+					owned += objectiveOwned;
+					if (task.KappaRequired == true) kappaOwned += objectiveOwned;
 					count += needed;
 					if (task.KappaRequired == true) kappaCount += needed;
 				} else if (objective.Type == "mark") {
@@ -93,16 +103,17 @@ public partial class Item {
 				}
 			}
 		}
-		return (count, kappaCount, total, kappaTotal);
+		return (count, kappaCount, total, kappaTotal, owned, kappaOwned);
 	}
 
-	public (int count, int total) GetHideoutRemaining(UserProgress? progress = null) {
+	public (int count, int total, int owned) GetHideoutRemaining(UserProgress? progress = null) {
 		progress ??= GetUserProgress();
 		progress.Tasks ??= new List<Progress>();
 		progress.TaskObjectives ??= new List<Progress>();
 
 		int count = 0;
 		int total = 0;
+		int owned = 0;
 		HideoutStation[] stations = TarkovDevAPI.GetHideoutStations();
 
 		foreach (HideoutStation station in stations) {
@@ -120,11 +131,16 @@ public partial class Item {
 					count += requiredItem.Count;
 					total += requiredItem.Count;
 					List<Progress> objectiveProgress = progress.HideoutParts.Where(p => p.Id == requiredItem.Id).ToList();
-					foreach (Progress p in objectiveProgress) count -= p.Complete ? requiredItem.Count : p.Count;
+					// Parts are still owned until the module is built, which is filtered out above
+					foreach (Progress p in objectiveProgress) {
+						int partOwned = p.Complete ? requiredItem.Count : p.Count;
+						count -= partOwned;
+						owned += partOwned;
+					}
 				}
 			}
 		}
-		return (count, total);
+		return (count, total, owned);
 	}
 
 	public IEnumerable<Item> GetAmmoOfSameCaliber() {

--- a/RatScanner/Pages/App/Index.razor
+++ b/RatScanner/Pages/App/Index.razor
@@ -53,10 +53,10 @@
         <MudItem xs="12">
             <MudPaper Class="d-flex align-center justify-space-around pa-1 mx-2 my-1" Elevation="2">
                 <div class="d-flex align-center">
-                    @MenuVM.TaskRemaining <MudIcon Icon="@Icons.Material.Filled.Checklist" Size="Size.Small" Class="ml-1" /> @Localizer["QuestLabel"]
+                    @MenuVM.TaskRemainingDisplay <MudIcon Icon="@Icons.Material.Filled.Checklist" Size="Size.Small" Class="ml-1" /> @Localizer["QuestLabel"]
                 </div>
                 <div class="d-flex align-center">
-                    @MenuVM.HideoutRemaining <MudIcon Icon="@Icons.Material.Filled.House" Size="Size.Small" Class="ml-1" /> @Localizer["HideoutLabel"]
+                    @MenuVM.HideoutRemainingDisplay <MudIcon Icon="@Icons.Material.Filled.House" Size="Size.Small" Class="ml-1" /> @Localizer["HideoutLabel"]
                 </div>
             </MudPaper>
         </MudItem>
@@ -64,7 +64,7 @@
             <MudItem xs="12">
                 <MudPaper Class="d-flex align-center justify-space-around pa-1 mx-2 my-1" Elevation="2">
                     <div class="d-flex align-center">
-                        @MenuVM.TaskRemainingKappa <MudIcon Icon="@Icons.Material.Filled.Checklist" Size="Size.Small" Class="ml-1" /> Kappa
+                        @MenuVM.TaskRemainingKappaDisplay <MudIcon Icon="@Icons.Material.Filled.Checklist" Size="Size.Small" Class="ml-1" /> Kappa
                     </div>
                 </MudPaper>
             </MudItem>

--- a/RatScanner/Pages/App/Settings/SettingsTracking.razor
+++ b/RatScanner/Pages/App/Settings/SettingsTracking.razor
@@ -13,17 +13,15 @@
         </MudItem>
         <MudItem xs="12">
             <MudPaper Class="align-center justify-center pa-2 mx-2 mb-2" Elevation="2">
-                <MudCheckBox @bind-Checked="SettingsVM.ShowNonFIRNeeds" Label="@Localizer["ShowNonFirNeeds"]" Size="Size.Small" Class="pa-0 ma-0"></MudCheckBox>
+                <MudGrid Spacing="0" Class="pa-0 ma-0">
+                    <MudCheckBox @bind-Checked="SettingsVM.ShowNonFIRNeeds" Label="@Localizer["ShowNonFirNeeds"]" Dense="true" Size="Size.Small" Class="pa-0 ma-0"></MudCheckBox>
+                    <MudCheckBox @bind-Checked="SettingsVM.ShowKappaNeeds" Label="@Localizer["ShowKappaNeeds"]" Dense="true" Size="Size.Small" Class="pa-0 ma-0"></MudCheckBox>
+                </MudGrid>
             </MudPaper>
         </MudItem>
         <MudItem xs="12">
             <MudPaper Class="align-center justify-center pa-2 mx-2 mb-2" Elevation="2">
-                <MudCheckBox @bind-Checked="SettingsVM.ShowKappaNeeds" Label="@Localizer["ShowKappaNeeds"]" Size="Size.Small" Class="pa-0 ma-0"></MudCheckBox>
-            </MudPaper>
-        </MudItem>
-        <MudItem xs="12">
-            <MudPaper Class="align-center justify-center pa-2 mx-2 mb-2" Elevation="2">
-                <MudGrid Spacing="1">
+                <MudGrid Spacing="0">
                     <MudItem xs="12">
                         <div class="d-flex justify-center">
                             @Localizer["TarkovTrackerTitle"]
@@ -38,9 +36,8 @@
                     <MudItem xs="12">
                         <MudTextField @bind-Value="SettingsVM.TarkovTrackerToken" Validation="@(new Func<string, IEnumerable<string>>(CheckToken))" Label="@Localizer["ApiToken"]" InputType="@PasswordInput" Variant="Variant.Outlined" Margin="Margin.Dense" Adornment="Adornment.End" AdornmentIcon="@PasswordInputIcon" OnAdornmentClick="TokenShowClick"></MudTextField>
                     </MudItem>
-                    <MudItem xs="12">
-                        <MudCheckBox @bind-Checked="SettingsVM.ShowTarkovTrackerTeam" Label="@Localizer["ShowTeammates"]" Size="Size.Small" Class="pa-0 ma-0"></MudCheckBox>
-                    </MudItem>
+                    <MudCheckBox @bind-Checked="SettingsVM.ShowTarkovTrackerTeam" Label="@Localizer["ShowTeammates"]" Dense="true" Size="Size.Small" Class="pa-0 ma-0"></MudCheckBox>
+                    <MudCheckBox @bind-Checked="SettingsVM.ShowCurrentItemProgress" Label="@Localizer["ShowCurrentItemProgress"]" Dense="true" Size="Size.Small" Class="pa-0 ma-0"></MudCheckBox>
                 </MudGrid>
             </MudPaper>
         </MudItem>

--- a/RatScanner/Pages/InteractableOverlay/Components/ItemSearchResult.razor
+++ b/RatScanner/Pages/InteractableOverlay/Components/ItemSearchResult.razor
@@ -17,8 +17,8 @@
                     @Item.GetTaskRemaining().Item1.ToShortString()
                 </MudChip>
                 <MudChip OnClose="() => { }" CloseIcon="@Icons.Material.Filled.House" Size="Size.Small"
-                         Variant="Variant.Outlined" Color="@(Item.GetHideoutRemaining() > 0 ? Color.Success : Color.Default)">
-                    @Item.GetHideoutRemaining().ToShortString()
+                         Variant="Variant.Outlined" Color="@(Item.GetHideoutRemaining().count > 0 ? Color.Success : Color.Default)">
+                    @Item.GetHideoutRemaining().count.ToShortString()
                 </MudChip>
             </MudStack>
 

--- a/RatScanner/Pages/Overlay/Index.razor
+++ b/RatScanner/Pages/Overlay/Index.razor
@@ -56,13 +56,13 @@
                             @if (MenuVM.TaskRemaining > 0)
                             {
                                 <div class="d-flex align-center stroke">
-                                    @MenuVM.TaskRemaining <MudIcon Icon="@Icons.Material.Filled.Checklist" Size="Size.Small" Class="ml-1" />
+                                    @MenuVM.TaskRemainingDisplay <MudIcon Icon="@Icons.Material.Filled.Checklist" Size="Size.Small" Class="ml-1" />
                                 </div>
                             }
                             @if (MenuVM.HideoutRemaining > 0)
                             {
                                 <div class="d-flex align-center stroke">
-                                    @MenuVM.HideoutRemaining <MudIcon Icon="@Icons.Material.Filled.House" Size="Size.Small" Class="ml-1" />
+                                    @MenuVM.HideoutRemainingDisplay <MudIcon Icon="@Icons.Material.Filled.House" Size="Size.Small" Class="ml-1" />
                                 </div>
                             }
                         </div>

--- a/RatScanner/RatConfig.cs
+++ b/RatScanner/RatConfig.cs
@@ -102,6 +102,8 @@ internal static class RatConfig {
 
 		internal static bool ShowKappaNeeds = false;
 
+		internal static bool ShowCurrentItemProgress = false;
+
 		internal static class TarkovTracker {
 			internal static TarkovTrackerBackend Backend = TarkovTrackerBackend.TarkovTrackerIO;
 			internal static string Endpoint => Backend == TarkovTrackerBackend.TarkovTrackerIO 
@@ -222,6 +224,7 @@ internal static class RatConfig {
 		config.Section = nameof(Tracking);
 		Tracking.ShowNonFIRNeeds = config.ReadBool(nameof(Tracking.ShowNonFIRNeeds), Tracking.ShowNonFIRNeeds);
 		Tracking.ShowKappaNeeds = config.ReadBool(nameof(Tracking.ShowKappaNeeds), Tracking.ShowKappaNeeds);
+		Tracking.ShowCurrentItemProgress = config.ReadBool(nameof(Tracking.ShowCurrentItemProgress), Tracking.ShowCurrentItemProgress);
 
 		config.Section = nameof(Tracking.TarkovTracker);
 		Tracking.TarkovTracker.Backend = (TarkovTrackerBackend)config.ReadInt(nameof(Tracking.TarkovTracker.Backend), (int)Tracking.TarkovTracker.Backend);
@@ -291,6 +294,7 @@ internal static class RatConfig {
 		config.Section = nameof(Tracking);
 		config.WriteBool(nameof(Tracking.ShowNonFIRNeeds), Tracking.ShowNonFIRNeeds);
 		config.WriteBool(nameof(Tracking.ShowKappaNeeds), Tracking.ShowKappaNeeds);
+		config.WriteBool(nameof(Tracking.ShowCurrentItemProgress), Tracking.ShowCurrentItemProgress);
 
 		config.Section = nameof(Tracking.TarkovTracker);
 		config.WriteInt(nameof(Tracking.TarkovTracker.Backend), (int)Tracking.TarkovTracker.Backend);

--- a/RatScanner/View/MinimalMenu.xaml
+++ b/RatScanner/View/MinimalMenu.xaml
@@ -96,7 +96,7 @@
 					<StackPanel Grid.Column="1"
 										Orientation="Horizontal"
 										HorizontalAlignment="Right">
-						<Label Content="{Binding TaskRemainingKappa, FallbackValue=0}" />
+						<Label Content="{Binding TaskRemainingKappaDisplay, FallbackValue=0}" />
 						<Image Source="{StaticResource kappaIcon}"
 								 VerticalAlignment="Center"
 								 Width="20"
@@ -133,7 +133,7 @@
 					<StackPanel Grid.Column="1"
 											Orientation="Horizontal"
 											HorizontalAlignment="Right">
-						<Label Content="{Binding TaskRemaining, FallbackValue=0}" />
+						<Label Content="{Binding TaskRemainingDisplay, FallbackValue=0}" />
 						<Image Source="{StaticResource questIcon}"
 									 VerticalAlignment="Center"
 									 Height="20" />
@@ -141,7 +141,7 @@
 					<StackPanel Grid.Column="2"
 											Orientation="Horizontal"
 											HorizontalAlignment="Right">
-						<Label Content="{Binding HideoutRemaining, FallbackValue=0}" />
+						<Label Content="{Binding HideoutRemainingDisplay, FallbackValue=0}" />
 						<Image Source="{StaticResource hideoutIcon}"
 									 VerticalAlignment="Center"
 									 Height="20" />

--- a/RatScanner/ViewModel/MenuVM.cs
+++ b/RatScanner/ViewModel/MenuVM.cs
@@ -47,7 +47,7 @@ internal class MenuVM : INotifyPropertyChanged {
 	public TraderPrice? BestTraderOffer => LastItem.GetBestTraderOffer();
 	public TraderPrice? BestTraderOfferVendor => LastItem.GetBestTraderOffer();
 
-    public (int count, int kappaCount, int total, int kappaTotal) TaskRemainingResult => LastItem.GetTaskRemaining();
+    public (int count, int kappaCount, int total, int kappaTotal, int owned, int kappaOwned) TaskRemainingResult => LastItem.GetTaskRemaining();
 
     public int TaskRemaining => TaskRemainingResult.count;
 
@@ -55,7 +55,7 @@ internal class MenuVM : INotifyPropertyChanged {
 
 	public bool KappaNeeded => TaskRemainingKappa > 0;
 
-	public (int count, int total) HideoutRemainingResult => LastItem.GetHideoutRemaining();
+	public (int count, int total, int owned) HideoutRemainingResult => LastItem.GetHideoutRemaining();
 
 	public int HideoutRemaining => HideoutRemainingResult.count;
 
@@ -65,29 +65,31 @@ internal class MenuVM : INotifyPropertyChanged {
 
 	public bool ShowCurrentItemProgress => RatConfig.Tracking.ShowCurrentItemProgress;
 
-	private static string FormatProgress(bool showProgress, int remaining, int total) {
+	// "owned" is how many of the item the player holds right now, "total" is how many are
+	// still required, which excludes the requirements of already finished tasks and modules
+	private static string FormatProgress(bool showProgress, int remaining, int owned, int total) {
 		if (!showProgress) return remaining.ToString();
-		return $"{total - remaining}/{total}";
+		return $"{owned}/{total}";
 	}
 
 	public string TaskRemainingDisplay {
 		get {
 			var result = TaskRemainingResult;
-			return FormatProgress(ShowCurrentItemProgress, result.count, result.total);
+			return FormatProgress(ShowCurrentItemProgress, result.count, result.owned, result.total);
 		}
 	}
 
 	public string TaskRemainingKappaDisplay {
 		get {
 			var result = TaskRemainingResult;
-			return FormatProgress(ShowCurrentItemProgress, result.kappaCount, result.kappaTotal);
+			return FormatProgress(ShowCurrentItemProgress, result.kappaCount, result.kappaOwned, result.kappaTotal);
 		}
 	}
 
 	public string HideoutRemainingDisplay {
 		get {
 			var result = HideoutRemainingResult;
-			return FormatProgress(ShowCurrentItemProgress, result.count, result.total);
+			return FormatProgress(ShowCurrentItemProgress, result.count, result.owned, result.total);
 		}
 	}
 

--- a/RatScanner/ViewModel/MenuVM.cs
+++ b/RatScanner/ViewModel/MenuVM.cs
@@ -47,19 +47,49 @@ internal class MenuVM : INotifyPropertyChanged {
 	public TraderPrice? BestTraderOffer => LastItem.GetBestTraderOffer();
 	public TraderPrice? BestTraderOfferVendor => LastItem.GetBestTraderOffer();
 
-    public (int count, int kappaCount) TaskRemainingResult => LastItem.GetTaskRemaining();
+    public (int count, int kappaCount, int total, int kappaTotal) TaskRemainingResult => LastItem.GetTaskRemaining();
 
     public int TaskRemaining => TaskRemainingResult.count;
 
     public int TaskRemainingKappa => TaskRemainingResult.kappaCount;
 
 	public bool KappaNeeded => TaskRemainingKappa > 0;
-	
-	public int HideoutRemaining => LastItem.GetHideoutRemaining();
+
+	public (int count, int total) HideoutRemainingResult => LastItem.GetHideoutRemaining();
+
+	public int HideoutRemaining => HideoutRemainingResult.count;
 
 	public bool ItemNeeded => TaskRemaining + HideoutRemaining > 0;
 
 	public bool ShowKappaNeeds => RatConfig.Tracking.ShowKappaNeeds;
+
+	public bool ShowCurrentItemProgress => RatConfig.Tracking.ShowCurrentItemProgress;
+
+	private static string FormatProgress(bool showProgress, int remaining, int total) {
+		if (!showProgress) return remaining.ToString();
+		return $"{total - remaining}/{total}";
+	}
+
+	public string TaskRemainingDisplay {
+		get {
+			var result = TaskRemainingResult;
+			return FormatProgress(ShowCurrentItemProgress, result.count, result.total);
+		}
+	}
+
+	public string TaskRemainingKappaDisplay {
+		get {
+			var result = TaskRemainingResult;
+			return FormatProgress(ShowCurrentItemProgress, result.kappaCount, result.kappaTotal);
+		}
+	}
+
+	public string HideoutRemainingDisplay {
+		get {
+			var result = HideoutRemainingResult;
+			return FormatProgress(ShowCurrentItemProgress, result.count, result.total);
+		}
+	}
 
 	public List<KeyValuePair<string, KeyValuePair<int, int>>>? ItemTeamNeeds {
 		get {
@@ -70,7 +100,7 @@ internal class MenuVM : INotifyPropertyChanged {
 			List<KeyValuePair<string, KeyValuePair<int, int>>> needs = new();
 			foreach (FetchModels.TarkovTracker.UserProgress? memberProgress in teamProgress) {
 				int task = LastItem.GetTaskRemaining(memberProgress).Item1;
-				int hideout = LastItem.GetHideoutRemaining(memberProgress);
+				int hideout = LastItem.GetHideoutRemaining(memberProgress).count;
 
 				if (task == 0 && hideout == 0) continue;
 

--- a/RatScanner/ViewModel/SettingsVM.cs
+++ b/RatScanner/ViewModel/SettingsVM.cs
@@ -42,6 +42,8 @@ internal class SettingsVM : INotifyPropertyChanged {
 
 	public bool ShowKappaNeeds { get; set; }
 
+	public bool ShowCurrentItemProgress { get; set; }
+
 	// TarkovTracker Specific Tracking Settings
 	public string TarkovTrackerToken { get; set; }
 
@@ -95,6 +97,7 @@ internal class SettingsVM : INotifyPropertyChanged {
 
 		ShowNonFIRNeeds = RatConfig.Tracking.ShowNonFIRNeeds;
 		ShowKappaNeeds = RatConfig.Tracking.ShowKappaNeeds;
+		ShowCurrentItemProgress = RatConfig.Tracking.ShowCurrentItemProgress;
 
 		TarkovTrackerToken = RatConfig.Tracking.TarkovTracker.Token;
 		ShowTarkovTrackerTeam = RatConfig.Tracking.TarkovTracker.ShowTeam;
@@ -141,6 +144,7 @@ internal class SettingsVM : INotifyPropertyChanged {
 
 		RatConfig.Tracking.ShowNonFIRNeeds = ShowNonFIRNeeds;
 		RatConfig.Tracking.ShowKappaNeeds = ShowKappaNeeds;
+		RatConfig.Tracking.ShowCurrentItemProgress = ShowCurrentItemProgress;
 
 		RatConfig.Tracking.TarkovTracker.Token = TarkovTrackerToken.Trim();
 		RatConfig.Tracking.TarkovTracker.ShowTeam = ShowTarkovTrackerTeam;

--- a/RatScanner/i18n/en.json
+++ b/RatScanner/i18n/en.json
@@ -33,6 +33,7 @@
   "TrackingSettingsTitle": "Tracking Settings",
   "ShowNonFIRNeeds": "Show Non-FIR Needs",
   "ShowKappaNeeds": "Show Kappa Needs",
+  "ShowCurrentItemProgress": "Show Current Item Progress",
   "BackendLabel": "Backend",
   "ApiToken": "API Token",
   "ShowTeammates": "Show Teammates",

--- a/RatScanner/i18n/es.json
+++ b/RatScanner/i18n/es.json
@@ -33,6 +33,7 @@
   "TrackingSettingsTitle": "Configuración de seguimiento",
   "ShowNonFirNeeds": "Mostrar necesidades no-FIR",
   "ShowKappaNeeds": "Mostrar necesidades para Kappa",
+  "ShowCurrentItemProgress": "Mostrar progreso actual del objeto",
   "BackendLabel": "Backend",
   "ApiToken": "Token de API",
   "ShowTeammates": "Mostrar compañeros",

--- a/RatScanner/i18n/fr.json
+++ b/RatScanner/i18n/fr.json
@@ -33,6 +33,7 @@
   "TrackingSettingsTitle": "Paramètres de suivi",
   "ShowNonFirNeeds": "Afficher les besoins non-FIR",
   "ShowKappaNeeds": "Afficher les besoins pour Kappa",
+  "ShowCurrentItemProgress": "Afficher la progression actuelle de l'objet",
   "BackendLabel": "Backend",
   "ApiToken": "Jeton API",
   "ShowTeammates": "Afficher les coéquipiers",

--- a/RatScanner/i18n/pl.json
+++ b/RatScanner/i18n/pl.json
@@ -33,6 +33,7 @@
   "TrackingSettingsTitle": "Ustawienia śledzenia",
   "ShowNonFirNeeds": "Pokaż potrzeby bez-FIR",
   "ShowKappaNeeds": "Pokaż potrzeby Kappa",
+  "ShowCurrentItemProgress": "Pokaż aktualny postęp przedmiotu",
   "BackendLabel": "Backend",
   "ApiToken": "Token API",
   "ShowTeammates": "Pokaż towarzyszy",

--- a/RatScanner/i18n/pt.json
+++ b/RatScanner/i18n/pt.json
@@ -33,6 +33,7 @@
   "TrackingSettingsTitle": "Configurações de rastreamento",
   "ShowNonFirNeeds": "Mostrar necessidades não-FIR",
   "ShowKappaNeeds": "Mostrar necessidades de Kappa",
+  "ShowCurrentItemProgress": "Mostrar progresso atual do item",
   "BackendLabel": "Backend",
   "ApiToken": "Token da API",
   "ShowTeammates": "Mostrar companheiros",

--- a/RatScanner/i18n/ru.json
+++ b/RatScanner/i18n/ru.json
@@ -33,6 +33,7 @@
   "TrackingSettingsTitle": "Настройки отслеживания",
   "ShowNonFirNeeds": "Показывать требования не-FIR",
   "ShowKappaNeeds": "Показывать требования для Kappa",
+  "ShowCurrentItemProgress": "Показывать текущий прогресс предмета",
   "BackendLabel": "Бэкенд",
   "ApiToken": "API токен",
   "ShowTeammates": "Показывать напарников",

--- a/RatScanner/i18n/zh.json
+++ b/RatScanner/i18n/zh.json
@@ -33,6 +33,7 @@
   "TrackingSettingsTitle": "追踪设置",
   "ShowNonFirNeeds": "显示非FIR需求",
   "ShowKappaNeeds": "显示 Kappa 需求",
+  "ShowCurrentItemProgress": "显示当前物品进度",
   "BackendLabel": "后端",
   "ApiToken": "API 令牌",
   "ShowTeammates": "显示队友",


### PR DESCRIPTION
Implements #861

Currently, there is only one format to display how many items you need: "How many of this item is needed". When the user has tracking enabled, this becomes dynamic to display "How many more of this item does the user need".

This PR adds a new feature to optionally change this with a more detailed display:

How many of these items does the player currently have (according to tracking data) / How many of these will the player ever need in this wipe

For example, if you haven't finished any quests and you have two Raven figurines in your inventory, it says "2/3" instead of "1". If you have the figurine AND you have finished the [Antique Enthusiast](https://escapefromtarkov.fandom.com/wiki/Antique_Enthusiast) quest, you will instead see 0/1. The same logic applies to hideout requirements.

This is helpful for stash management, so that you can know which items from your stash you're free to sell.

Turned off by default, it can be turned on from the Tracking Settings (placed there because it is only useful if you have tracking enabled)
 
<img width="483" height="482" alt="image" src="https://github.com/user-attachments/assets/65b5b3ce-69e7-4b6c-9325-6b9ec986fa3f" />